### PR TITLE
test: submitTalentRegister UI integration 테스트 (#9)

### DIFF
--- a/.plans/submit-talent-register-integration-tests/plan.md
+++ b/.plans/submit-talent-register-integration-tests/plan.md
@@ -1,0 +1,89 @@
+# submitTalentRegister UI integration 테스트
+
+## 무엇을 / 왜
+
+**무엇을**
+
+- `submitTalentRegister` 단위 테스트로 고정되지 않는 UI 상호작용 구간을 `@testing-library/react` 기반 integration 테스트로 검증한다.
+- 특히 `TalentRegisterNav`의 임시저장 debounce, `page.tsx`의 `methods.reset(...)`, `useFieldArray` 기반 섹션 추가/삭제 후 재저장 흐름을 테스트 대상으로 삼는다.
+- 백엔드가 내려가 있어 E2E를 돌릴 수 없는 동안, jsdom + API mock 환경에서 프론트에서 재현 가능한 회귀를 최대한 먼저 고정한다.
+
+**왜**
+
+- 현재 `_actions/__tests__`의 단위 테스트는 payload 조립과 POST/PUT/skip 분기는 잘 커버하지만, 실제 화면에서 버튼 클릭 → 입력 → reset → 다음 저장까지 이어지는 상태 전이는 직접 검증하지 못한다.
+- `submitTalentRegister.ts`는 일부 섹션을 `defaultValues` 비교, 일부 섹션을 `dirtyFields`로 판단한다. 이 차이는 `methods.reset(...)`와 결합될 때 실제 UI에서만 드러나는 버그를 만들 수 있다.
+- 사용자 제보 이슈도 “추가/삭제/임시저장 연타 후 중복 POST”처럼 React Hook Form과 컴포넌트 상호작용 레이어에 가까워, unit test만으로는 회귀 방지가 부족하다.
+- 현재 백엔드가 죽어 있어 Playwright/E2E로 올바른 서버 상태까지 확인할 수 없으므로, 지금 할 수 있는 최선은 integration 테스트로 프론트 흐름을 먼저 고정하는 것이다.
+
+## 현재 상태 진단
+
+- 현재 브랜치: `test/7-submit-talent-register-remaining-tests`
+- 기존 테스트 범위:
+  - `_actions/__tests__/submitTalentRegister.test.ts`: 공통 플로우
+  - `_actions/__tests__/submitTalentRegister.arraySections.test.ts`: 학력/경력/활동/언어/자격증 배열 섹션
+  - `_actions/__tests__/submitTalentRegister.choiceSections.test.ts`: 링크/jobs/expTags/customSkills/workDriven
+- 현재 빠진 검증 층:
+  - `TalentRegisterNav`의 1초 debounce 이후 실제 `onTempSave`가 한 번만 호출되는지
+  - `page.tsx`에서 임시저장 성공 후 `methods.reset(result.data, { keepDirty: true ... })`가 다음 저장 판단에 어떤 영향을 주는지
+  - `EducationSection`, `CareerSection` 등 `useFieldArray` 섹션에서 추가/삭제 후 `reset(currentValues, ...)`가 defaultValues를 의도대로 갱신하는지
+  - 실제 화면 이벤트 기준으로 “첫 저장은 POST, 두 번째 저장은 PUT/skip”이 유지되는지
+  - 성공/실패 토스트가 중복 호출되거나 예상과 다르게 노출되는지
+- 테스트 인프라는 이미 준비되어 있다.
+  - `vitest.config.ts`에서 `jsdom` 환경과 `test/setup.ts`가 설정되어 있다.
+  - `@testing-library/react`, `@testing-library/user-event`, `jsdom` 의존성이 이미 설치되어 있다.
+- 제약:
+  - 백엔드가 내려가 있어 실제 서버 상태, DB 반영 수, 브라우저 네트워크 탭 기준 E2E 검증은 당장 불가능하다.
+  - 따라서 이번 단계의 계약은 “UI 상호작용이 올바른 API 호출 수와 인자를 만든다”까지다.
+
+## 해결책
+
+- 페이지 전체를 바로 E2E처럼 렌더링하지 않고, 먼저 `FormProvider + TalentRegisterNav + 대상 섹션 + submit handler`를 묶은 최소 harness integration 테스트를 만든다.
+- 첫 테스트 범위는 실제 버그 가능성이 높은 흐름부터 시작한다: 임시저장 debounce, 배열 섹션 추가 후 저장, 저장 응답으로 reset 후 재저장, 삭제 후 재저장.
+- 네트워크는 실제 백엔드 대신 기존 API mock을 재사용하거나 컴포넌트 테스트 전용 mock으로 분리해, 호출 횟수와 payload만 검증한다.
+- `page.tsx` 전체 렌더링이 너무 무거우면 `handleTempSave`와 동일 계약을 가진 테스트용 wrapper를 만들어 RHF 상태 전이만 고정한다.
+- integration 테스트에서 드러난 실제 버그만 최소 수정한다. 구조 리팩토링은 이번 계획 범위에서 제외한다.
+
+## 트레이드오프
+
+| 선택 | 장점 | 단점 |
+|---|---|---|
+| Testing Library integration 테스트 | 백엔드 없이도 UI 흐름과 RHF 상태 전이를 검증 가능 | 세팅과 mock이 unit test보다 무겁다 |
+| 최소 harness 방식 | 테스트 실패 원인이 비교적 선명하고 유지비가 낮다 | 실제 페이지 전체 컨텍스트 일부는 생략된다 |
+| 페이지 전체 대신 섹션/내비 중심 검증 | 핵심 버그를 빠르게 고정 가능 | router, query hook, store 연동 회귀는 일부 남는다 |
+| E2E를 뒤로 미루고 integration 먼저 작성 | 현재 제약 아래에서 바로 진행 가능 | 실제 서버 상태와 브라우저 네트워크 결과까지는 보장하지 못한다 |
+| 발견 버그를 같은 PR에서 최소 수정 | 테스트와 수정 근거가 한곳에 남는다 | 순수 테스트 PR보다 리뷰 범위가 넓어진다 |
+
+## 대안
+
+1. **백엔드가 살아날 때까지 E2E만 기다린다**
+   - 기각 이유: 지금 재현 가능한 프론트 회귀를 방치하게 되고, 반복 저장/삭제 같은 UI 상태 버그는 지금도 충분히 잡을 수 있다.
+2. **기존 unit test를 더 늘린다**
+   - 기각 이유: payload 분기는 이미 상당 부분 고정되었다. 지금 부족한 건 이벤트 기반 상태 전이라 같은 층 테스트를 늘려도 공백이 남는다.
+3. **Playwright에서 API route mock으로 E2E 흉내를 낸다**
+   - 기각 이유: 장기적으로는 가능하지만, 현재 레포에는 그 인프라가 없고 이번 목적은 브라우저 자동화보다 RHF 흐름 검증이 우선이다.
+4. **페이지 전체를 통째로 렌더링하는 거대한 integration 테스트 하나만 작성한다**
+   - 기각 이유: router, store, query hook mock 비용이 크고 실패 원인 파악이 어려워 유지보수성이 낮다.
+
+## 완료 기준
+
+- [ ] integration 테스트 파일이 새로 추가된다
+  - 위치는 `app/dashboard/profile/[profileId]/__tests__` 또는 이에 준하는 UI 테스트 전용 경로
+- [ ] 임시저장 debounce 테스트 통과
+  - 짧은 시간 연속 클릭 시 저장 핸들러가 1회만 실행됨
+- [ ] 배열 섹션 추가 후 저장 테스트 통과
+  - 사용자가 항목을 추가하고 값을 입력한 뒤 임시저장하면 관련 POST API가 1회만 호출됨
+- [ ] reset 후 재저장 테스트 통과
+  - 첫 저장 응답으로 id가 주어진 뒤 다시 임시저장하면 같은 항목에 대해 중복 POST가 발생하지 않음
+- [ ] 배열 섹션 삭제 후 재저장 테스트 통과
+  - 삭제 후 `reset(currentValues, ...)`가 반영되어 삭제된 항목이 다음 저장 판단에 잘못 남지 않음
+- [ ] jobs / expTags처럼 dirtyFields 기반 분기 중 최소 1개는 integration 관점에서도 재검증한다
+  - 반복 저장 시 호출 조건이 의도와 맞는지 명시적으로 고정
+- [ ] 성공/실패 토스트 노출이 기대와 다르면 테스트로 고정하고, 실제 버그면 최소 수정으로 해결한다
+- [ ] `npm test -- <integration-test-pattern>` 통과
+- [ ] 관련 기존 `submitTalentRegister` unit test가 계속 통과한다
+- [ ] `npm run type-check` 통과
+- [ ] 이번 작업은 E2E 대체가 아니라 프론트 integration 보강이라는 점이 plan/task에 명시된다
+
+## 다음 단계
+
+사용자가 이 계획에 "진행"이라고 승인하면 `.plans/submit-talent-register-integration-tests/task.md`를 작성한다. task.md에서는 테스트 대상을 `Nav debounce → 배열 섹션 reset → dirtyFields/토스트 보강 → 전체 검증` 순서로 커밋 단위로 분할한다.

--- a/.plans/submit-talent-register-integration-tests/task.md
+++ b/.plans/submit-talent-register-integration-tests/task.md
@@ -1,0 +1,254 @@
+# submitTalentRegister UI integration 테스트 — Task 분할
+
+> plan: [plan.md](./plan.md)
+> 이슈: `TBD` `test: submitTalentRegister UI integration 테스트`
+> 대상 브랜치: `TBD` `test/<issue-num>-submit-talent-register-integration-tests`
+> 원칙: task 1개 = 커밋 1개. 각 task는 실패 테스트 작성 → red 확인 → 최소 수정 → green 확인 순서로 진행한다.
+> 참고: 이 문서는 task 분할 문서다. 실제 구현 착수 전에는 `.agents/workflow.md`에 따라 새 issue/branch를 만들고, 첫 커밋 push 이후 draft PR을 생성한다.
+
+## 본 PR 의 스코프
+
+- **포함**: `@testing-library/react` 기반 integration 테스트 하네스, `TalentRegisterNav` debounce/validation, 배열 섹션 추가·저장·reset·삭제 흐름, 최소 1개의 dirtyFields 기반 저장 흐름, 토스트 노출 검증, 테스트 중 발견되는 실제 버그의 최소 수정
+- **제외**: Playwright/E2E, 백엔드·DB 검증, `page.tsx` 전체에 대한 무거운 end-to-end 수준 렌더링, submit 로직 구조 리팩토링, API 계약 변경
+- **기본 테스트 위치 후보**: `app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx`
+- **기본 헬퍼 위치 후보**: `app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx`
+- **mock 위치 후보**: `app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.mocks.ts`
+
+## 설계 원칙
+
+- 현재 목적은 “브라우저 전체”가 아니라 “RHF 상태 전이 + 사용자 상호작용” 검증이다.
+- 따라서 페이지 전체를 바로 렌더링하지 않고, 먼저 `FormProvider + TalentRegisterNav + 대상 섹션 + page.tsx 와 같은 temp-save wrapper`를 묶은 최소 하네스를 만든다.
+- API 는 실제 백엔드 대신 mock 으로 고정하고, 이번 단계의 검증 계약은 “어떤 UI 흐름에서 어떤 API 호출이 몇 번 나가는가”까지로 제한한다.
+- 실제 버그가 드러나면 테스트를 먼저 고정하고, 수정 범위는 `TalentRegisterNav`, 해당 섹션 컴포넌트, `submitTalentRegister`, 또는 테스트 하네스에 필요한 최소 범위로 제한한다.
+
+## 의존성 순서
+
+```text
+T1 integration 하네스/공용 mock
+  └─► T2 Nav debounce + 임시저장 validation
+        └─► T3 학력 섹션 첫 저장 + reset 후 재저장
+              └─► T4 배열 섹션 삭제 + 재저장
+                    └─► T5 dirtyFields 기반 저장 흐름 재검증
+                          └─► T6 토스트/실패 처리
+                                └─► T7 전체 검증·PR 정리
+```
+
+T3~T4는 같은 하네스를 공유한다. 우선 실제 제보 맥락과 가장 가까운 `EducationSection`을 기준으로 고정한 뒤, 필요하면 다른 배열 섹션으로 확장한다.
+
+---
+
+## T1 — integration 하네스·공용 mock 스캐폴드
+
+**보장할 동작**: UI integration 테스트를 위한 최소 하네스가 준비되고, 이후 task 가 같은 wrapper/mocks 를 재사용할 수 있다.
+
+**먼저 쓸 실패 테스트**
+
+- 새 테스트 파일이 Vitest 에서 탐지되고 jsdom 환경에서 렌더링된다.
+- 최소 하네스 렌더 시 `TalentRegisterNav` 와 대상 섹션이 정상 마운트된다.
+- 공용 mock 로딩 후 외부 네트워크 없이 테스트가 실행된다.
+
+**구현 방침**
+
+- `renderSubmitTalentRegisterHarness(...)` 같은 helper 를 만든다.
+- 하네스는 아래 계약을 가진다.
+  - `FormProvider` 로 RHF 제공
+  - `TalentRegisterNav` 렌더
+  - 섹션 컴포넌트 하나 또는 복수 렌더
+  - `page.tsx` 의 `handleTempSave` 와 같은 wrapper 사용
+  - 저장 성공 시 `methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true })`
+- `next/navigation`, `useToastStore`, 필요한 API 모듈은 integration 테스트 전용 mock 으로 분리한다.
+- 가능하면 기존 `_actions/__tests__/submitTalentRegister.mocks.ts` 와 중복을 줄이되, 컴포넌트용 mock 은 UI 테스트 경로에 독립적으로 둔다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+
+**완료 기준**: integration 테스트 골격이 green 이고, 다음 task 에서 helper/mocks 를 그대로 재사용할 수 있다.
+
+**커밋**: `test: submitTalentRegister integration 하네스 스캐폴드`
+
+---
+
+## T2 — Nav debounce + 임시저장 validation
+
+**보장할 동작**: `TalentRegisterNav` 의 임시저장 버튼은 짧은 시간 연속 클릭 시 저장을 1회만 실행하고, temp-save validation 실패 시 저장을 막는다.
+
+**먼저 쓸 실패 테스트**
+
+- 임시저장 버튼 2~3회 연속 클릭 + 1초 이전 → 저장 핸들러 호출 0회
+- 같은 흐름에서 1초 경과 → 저장 핸들러 호출 1회
+- validation 실패 값 상태에서 임시저장 → 저장 핸들러 호출 0회 + 에러 토스트 1회
+- debounce 대기 중 다시 클릭하면 이전 타이머가 취소되고 마지막 클릭 기준으로 1회만 실행
+
+**구현 방침**
+
+- `vi.useFakeTimers()` 를 사용해 debounce 를 결정적으로 검증한다.
+- 이 task 는 우선 `TalentRegisterNav` 중심 테스트로 시작한다. 아직 `submitTalentRegister` 전체 흐름과 묶지 않아도 된다.
+- selector 는 role/name 기반을 우선 사용하고, 필요하면 title input 과 임시저장 버튼에 대한 접근성 질의를 보강한다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+
+**완료 기준**: debounce/validation 테스트가 green 이고, 클릭 연타 시 중복 저장 실행이 방지된다.
+
+**커밋**: `test: TalentRegisterNav 임시저장 debounce 와 validation 검증`
+
+---
+
+## T3 — 학력 섹션 첫 저장 + reset 후 재저장
+
+**보장할 동작**: 사용자가 학력을 추가하고 임시저장하면 첫 저장은 POST 되고, 응답으로 받은 id 로 reset 된 뒤 다시 임시저장해도 중복 POST 가 발생하지 않는다.
+
+**먼저 쓸 실패 테스트**
+
+- 학력 1개 추가 + 필수값 입력 + 임시저장 → `createEducations` 1회
+- `createEducations` 응답에 id 를 반환하면 하네스 wrapper 가 `methods.reset(...)` 를 수행
+- 같은 데이터로 다시 임시저장 → `createEducations` 호출 횟수 추가 없음
+- 두 번째 저장 시 필요하면 `updateEducation` 또는 skip 이고, “같은 신규 항목이 다시 POST” 되는 일은 없음
+
+**구현 방침**
+
+- 실제 `EducationSection` 을 렌더링하고, `userEvent` 로 “학력 추가”, 입력, 임시저장 클릭 흐름을 그대로 밟는다.
+- 저장 결과 반영은 하네스 내부의 temp-save wrapper 가 담당한다. `page.tsx` 의 reset 옵션을 그대로 맞춘다.
+- 이 task 의 핵심 assert 는 “첫 저장 후 서버 id 가 기본값으로 반영되어 다음 저장 판단이 바뀌는가”다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+- 필요 시 `npm test -- submitTalentRegister`
+
+**완료 기준**: 학력 중복 POST 회귀가 integration 테스트로 고정된다.
+
+**커밋**: `test: 학력 임시저장 reset 후 중복 POST 방지 검증`
+
+---
+
+## T4 — 배열 섹션 삭제 + 재저장 흐름
+
+**보장할 동작**: 배열 섹션에서 항목 삭제 후 `reset(currentValues, ...)` 가 defaultValues 를 갱신해, 다음 저장 판단에 삭제된 항목이 잘못 남지 않는다.
+
+**먼저 쓸 실패 테스트**
+
+- 기존 id 가 있는 학력 또는 경력 1개를 렌더링
+- 삭제 버튼 클릭 → 필요 시 delete API 호출 1회 + 화면에서 항목 제거
+- 삭제 직후 섹션 컴포넌트의 `reset(currentValues, ...)` 반영
+- 이후 임시저장 → 삭제된 항목에 대한 create/update 가 잘못 다시 호출되지 않음
+- delete API 실패 시 항목이 제거되지 않고 에러 메시지가 노출됨
+
+**구현 방침**
+
+- 우선 `EducationSection` 으로 시작하고, 삭제 UI selector 가 더 안정적인 섹션을 선택한다.
+- 삭제 테스트는 섹션 컴포넌트 자체의 `remove + reset` 동작과 temp-save wrapper 이후 흐름을 같이 본다.
+- 실제 버그가 학력보다 경력에서 재현되기 쉬우면 task 범위 안에서 `CareerSection` 으로 전환 가능하다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+
+**완료 기준**: 배열 삭제 후 재저장에서 잘못된 재생성/재저장이 발생하지 않는다는 계약이 고정된다.
+
+**커밋**: `test: 배열 섹션 삭제 후 재저장 흐름 검증`
+
+---
+
+## T5 — dirtyFields 기반 저장 흐름 재검증
+
+**보장할 동작**: dirtyFields 기반으로 저장하는 섹션도 실제 UI 입력 흐름에서 호출 조건이 의도대로 유지된다.
+
+**먼저 쓸 실패 테스트**
+
+- 최소 1개 대상을 고른다: `jobs` 또는 `expTags`
+- 값 변경 없이 반복 임시저장 → 불필요한 PUT 이 반복되지 않음 또는 현재 의도된 동작을 명시적으로 고정
+- 관련 입력 변경 후 임시저장 → 해당 PUT 1회
+- reset 이후 다시 동일 값으로 임시저장 → 추가 PUT 여부를 계약으로 고정
+
+**구현 방침**
+
+- `JobSection` 전체가 무거우면, RHF 에 실제로 `register("job.role")`, `register("job.category")`, `register("job.experiences")` 를 연결한 최소 입력 하네스를 먼저 쓴다.
+- 이 task 의 목적은 섹션 UI 자체보다 `dirtyFields` 와 temp-save/reset 결합 결과를 보는 것이다.
+- 현재 동작이 합리적이지 않으면 실패 테스트를 먼저 남기고 최소 수정으로 바로잡는다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+- 필요 시 `npm test -- submitTalentRegister`
+
+**완료 기준**: dirtyFields 기반 분기 중 최소 1개가 integration 층에서도 회귀 방지된다.
+
+**커밋**: `test: dirtyFields 기반 저장 흐름 integration 검증`
+
+---
+
+## T6 — 토스트·실패 처리 검증
+
+**보장할 동작**: 성공/실패 토스트가 기대 횟수로만 노출되고, 저장 실패 시 성공 UI 가 함께 뜨지 않는다.
+
+**먼저 쓸 실패 테스트**
+
+- 임시저장 성공 시 성공 토스트 1회만 노출
+- 저장 실패 시 에러 토스트 1회만 노출하고 성공 토스트는 노출되지 않음
+- validation 실패 토스트와 저장 실패 토스트가 섞이지 않음
+- 실제로 중복 토스트가 뜬다면 이를 버그로 고정하고 최소 수정
+
+**구현 방침**
+
+- `useToastStore` mock 호출 횟수와 인자를 기준으로 검증한다.
+- 이 task 는 T2/T3 하네스를 재사용해 “Nav + page wrapper” 전체 조합에서 토스트가 몇 번 뜨는지 확인한다.
+- 성공 토스트 중복이 현재 구조상 의도치 않은 동작이면, 어느 레이어가 책임을 가져야 하는지 정하고 한 곳으로 정리한다.
+
+**검증**
+
+- `npm test -- submitTalentRegister.integration`
+
+**완료 기준**: 토스트 노출 계약이 테스트로 고정되고, 실패 시 사용자 피드백이 일관된다.
+
+**커밋**: `test: 임시저장 토스트 와 실패 처리 검증`
+
+---
+
+## T7 — 전체 검증·PR 정리
+
+**보장할 동작**: 이번 integration 테스트 PR 의 로컬 검증이 통과하고, 후속 workflow 문서 기준으로 PR 준비가 가능하다.
+
+**먼저 쓸 테스트 / 검증**
+
+- `npm test -- submitTalentRegister.integration`
+- `npm test -- submitTalentRegister`
+- `npm run type-check`
+- 필요 시 `npm run test:coverage`
+
+**작업**
+
+- 실패한 검증이 있으면 원인 task 로 돌아가 수정하고 해당 task 커밋에 포함한다.
+- 구현 시작 전에 workflow 단계가 아직 안 되어 있었다면 이 시점 이전에 반드시 아래를 수행한다.
+  - issue 생성
+  - 새 브랜치 생성
+  - 첫 커밋 push 후 draft PR 생성
+- PR 본문에는 integration 테스트 task 체크리스트, 테스트 명령, 리스크/롤백을 기록한다.
+- 모든 task 완료 + CI green 후 `gh pr ready`.
+
+**완료 기준**: integration 테스트와 관련 unit test/type-check 가 green 이고, PR 이 ready 전환 가능한 상태다.
+
+**커밋**: 별도 코드 변경이 없다면 커밋 없음. 문서/PR 본문만 필요하면 `docs: submitTalentRegister integration 테스트 작업 상태 정리`
+
+---
+
+## 하네스 체크리스트
+
+- [x] plan 승인
+- [ ] task 승인
+- [ ] workflow 단계 수행: issue 생성
+- [ ] workflow 단계 수행: 새 브랜치 생성
+- [ ] T1 완료 후 첫 커밋 push
+- [ ] draft PR 생성
+- [ ] task 완료마다 PR 본문 체크박스 업데이트
+- [ ] integration 테스트 green
+- [ ] 관련 unit test green
+- [ ] type-check green
+- [ ] CI green
+- [ ] `gh pr ready`
+
+## 승인 후 첫 작업
+
+사용자가 이 task 분할에 "좋아"라고 승인하면, 구현에 들어가기 전에 `.agents/workflow.md`에 따라 새 issue/branch 를 만들고 T1부터 착수한다. T1의 첫 동작은 integration 테스트 파일과 하네스 helper 를 추가하고 `npm test -- submitTalentRegister.integration` 로 red 를 확인하는 것이다.

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { FormProvider, useForm, type UseFormReturn } from "react-hook-form";
 
 import type { TalentRegisterFormValues } from "@/schemas/talent/talentRegisterSchema";
+import { useToastStore } from "@/store/toastStore";
 
 import { cloneDefaultValues } from "../_actions/__tests__/submitTalentRegister.helpers";
 import { submitTalentRegister } from "../_actions/submitTalentRegister";
@@ -29,6 +30,17 @@ interface HarnessProps extends RenderHarnessOptions {
   formId: string;
 }
 
+function isTempSaveResult(
+  value: unknown
+): value is { success: boolean; data?: TalentRegisterFormValues } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "success" in value &&
+    typeof (value as { success: unknown }).success === "boolean"
+  );
+}
+
 function SubmitTalentRegisterIntegrationHarness({
   children,
   formId,
@@ -40,24 +52,25 @@ function SubmitTalentRegisterIntegrationHarness({
   const methods = useForm<TalentRegisterFormValues>({
     defaultValues: initialValues ?? cloneDefaultValues(),
   });
+  const showToast = useToastStore((state) => state.showToast);
 
   const handleTempSave = async () => {
     const values = methods.getValues();
+    const result = onTempSave
+      ? await onTempSave({ values, methods, profileId })
+      : await submitTalentRegister({
+          values,
+          methods,
+          profileId,
+          isTempSave: true,
+        });
 
-    if (onTempSave) {
-      return onTempSave({ values, methods, profileId });
-    }
-
-    const result = await submitTalentRegister({
-      values,
-      methods,
-      profileId,
-      isTempSave: true,
-    });
-
-    if (result.success && result.data) {
-      // page.tsx 와 같은 reset 옵션을 유지해 재저장 흐름을 재현한다.
-      methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true });
+    if (isTempSaveResult(result) && result.success) {
+      if (result.data) {
+        // page.tsx 와 같은 reset 옵션을 유지해 재저장 흐름을 재현한다.
+        methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true });
+      }
+      showToast("임시 저장되었습니다!");
     }
 
     return result;

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
@@ -1,0 +1,106 @@
+import "./submitTalentRegister.integration.mocks";
+
+import type { ReactNode } from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm, type UseFormReturn } from "react-hook-form";
+
+import type { TalentRegisterFormValues } from "@/schemas/talent/talentRegisterSchema";
+
+import { cloneDefaultValues } from "../_actions/__tests__/submitTalentRegister.helpers";
+import { submitTalentRegister } from "../_actions/submitTalentRegister";
+import TalentRegisterNav from "../_components/TalentRegisterNav";
+
+interface TempSaveHandlerParams {
+  methods: UseFormReturn<TalentRegisterFormValues>;
+  profileId: number;
+  values: TalentRegisterFormValues;
+}
+
+interface RenderHarnessOptions {
+  children?: ReactNode;
+  initialValues?: TalentRegisterFormValues;
+  isSubmitDisabled?: boolean;
+  onTempSave?: (params: TempSaveHandlerParams) => Promise<unknown> | unknown;
+  profileId?: number;
+}
+
+interface HarnessProps extends RenderHarnessOptions {
+  formId: string;
+}
+
+function SubmitTalentRegisterIntegrationHarness({
+  children,
+  formId,
+  initialValues,
+  isSubmitDisabled = false,
+  onTempSave,
+  profileId = 1,
+}: HarnessProps) {
+  const methods = useForm<TalentRegisterFormValues>({
+    defaultValues: initialValues ?? cloneDefaultValues(),
+  });
+
+  const handleTempSave = async () => {
+    const values = methods.getValues();
+
+    if (onTempSave) {
+      return onTempSave({ values, methods, profileId });
+    }
+
+    const result = await submitTalentRegister({
+      values,
+      methods,
+      profileId,
+      isTempSave: true,
+    });
+
+    if (result.success && result.data) {
+      // page.tsx 와 같은 reset 옵션을 유지해 재저장 흐름을 재현한다.
+      methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true });
+    }
+
+    return result;
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <TalentRegisterNav
+        formId={formId}
+        isSubmitDisabled={isSubmitDisabled}
+        onTempSave={handleTempSave}
+      />
+      <form id={formId}>{children}</form>
+    </FormProvider>
+  );
+}
+
+export function createIntegrationValues(overrides?: Partial<TalentRegisterFormValues>) {
+  return {
+    ...cloneDefaultValues(),
+    ...overrides,
+  } as TalentRegisterFormValues;
+}
+
+export function renderSubmitTalentRegisterHarness(
+  { children, initialValues, isSubmitDisabled, onTempSave, profileId }: RenderHarnessOptions = {},
+  userOptions?: Parameters<typeof userEvent.setup>[0]
+) {
+  const user = userEvent.setup(userOptions);
+  const formId = "submit-talent-register-integration-form";
+
+  return {
+    user,
+    ...render(
+      <SubmitTalentRegisterIntegrationHarness
+        formId={formId}
+        initialValues={initialValues}
+        isSubmitDisabled={isSubmitDisabled}
+        onTempSave={onTempSave}
+        profileId={profileId}
+      >
+        {children}
+      </SubmitTalentRegisterIntegrationHarness>
+    ),
+  };
+}

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.mocks.ts
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.mocks.ts
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { vi } from "vitest";
+
+import "../_actions/__tests__/submitTalentRegister.mocks";
+
+export const routerPushMock = vi.fn();
+export const showToastMock = vi.fn();
+export const hideToastMock = vi.fn();
+
+type ToastType = "success" | "error" | "info";
+
+interface ToastStoreState {
+  isVisible: boolean;
+  message: string;
+  type: ToastType;
+  showToast: typeof showToastMock;
+  hideToast: typeof hideToastMock;
+}
+
+export const useToastStoreMock = vi.fn((selector?: (state: ToastStoreState) => unknown) => {
+  const state: ToastStoreState = {
+    isVisible: false,
+    message: "",
+    type: "success",
+    showToast: showToastMock,
+    hideToast: hideToastMock,
+  };
+
+  return selector ? selector(state) : state;
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => createElement("img", props),
+}));
+
+vi.mock("@/store/toastStore", () => ({
+  useToastStore: useToastStoreMock,
+}));
+
+export function resetIntegrationMocks() {
+  routerPushMock.mockReset();
+  showToastMock.mockReset();
+  hideToastMock.mockReset();
+  useToastStoreMock.mockClear();
+}

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.mocks.ts
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.mocks.ts
@@ -44,6 +44,7 @@ vi.mock("@/store/toastStore", () => ({
 }));
 
 export function resetIntegrationMocks() {
+  vi.clearAllMocks();
   routerPushMock.mockReset();
   showToastMock.mockReset();
   hideToastMock.mockReset();

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -180,5 +180,93 @@ describe("EducationSection integration (T3)", () => {
     expect(educationsApi.createEducations).not.toHaveBeenCalled();
     expect(educationsApi.updateEducation).not.toHaveBeenCalled();
     expect(showToastMock).toHaveBeenCalledWith("임시 저장되었습니다!");
+  });
+});
+
+describe("EducationSection integration (T4)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+  });
+
+  it("기존 학력을 삭제하면 다음 임시저장에서 삭제된 항목을 다시 저장하지 않는다", async () => {
+    const educationsApi = await import("@/lib/api/educations");
+
+    renderSubmitTalentRegisterHarness({
+      children: <EducationSection profileId={1} />,
+      initialValues: createIntegrationValues({
+        educations: [
+          {
+            id: 77,
+            schoolName: "연성대학교",
+            major: "컴퓨터공학",
+            status: "GRADUATED",
+            startDate: "2020-03",
+            endDate: "2024-02",
+            description: "",
+            degree: "",
+          },
+        ],
+      }),
+      profileId: 1,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => {
+      expect(educationsApi.deleteEducation).toHaveBeenCalledWith(1, 77);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
+    });
+
+    vi.mocked(educationsApi.createEducations).mockClear();
+    vi.mocked(educationsApi.updateEducation).mockClear();
+    showToastMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1100);
+    });
+
+    expect(educationsApi.createEducations).not.toHaveBeenCalled();
+    expect(educationsApi.updateEducation).not.toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledWith("임시 저장되었습니다!");
+  });
+
+  it("학력 삭제 API 가 실패하면 항목을 유지하고 에러 메시지를 보여준다", async () => {
+    const educationsApi = await import("@/lib/api/educations");
+
+    vi.mocked(educationsApi.deleteEducation).mockRejectedValueOnce(
+      new Error("학력 삭제에 실패했습니다.")
+    );
+
+    renderSubmitTalentRegisterHarness({
+      children: <EducationSection profileId={1} />,
+      initialValues: createIntegrationValues({
+        educations: [
+          {
+            id: 77,
+            schoolName: "연성대학교",
+            major: "컴퓨터공학",
+            status: "GRADUATED",
+            startDate: "2020-03",
+            endDate: "2024-02",
+            description: "",
+            degree: "",
+          },
+        ],
+      }),
+      profileId: 1,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "삭제" }));
+
+    await waitFor(() => {
+      expect(educationsApi.deleteEducation).toHaveBeenCalledWith(1, 77);
+    });
+
+    expect(screen.getByText("학력 삭제에 실패했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
   });
 });

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -74,7 +74,7 @@ describe("TalentRegisterNav integration (T2)", () => {
   });
 
   it("임시저장 버튼을 연속 클릭해도 마지막 클릭 기준 1초 뒤에 저장을 1회만 실행한다", async () => {
-    const onTempSave = vi.fn().mockResolvedValue(undefined);
+    const onTempSave = vi.fn().mockResolvedValue({ success: true });
     renderSubmitTalentRegisterHarness({
       initialValues: createIntegrationValues(),
       onTempSave,
@@ -370,5 +370,51 @@ describe("jobs dirtyFields integration (T5)", () => {
 
     expect(jobsApi.updateJobs).toHaveBeenCalledTimes(2);
     expect(jobsApi.updateJobs).toHaveBeenNthCalledWith(2, 1, { ids: [1] });
+  });
+});
+
+describe("temp-save toast integration (T6)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("임시저장이 성공하면 성공 토스트는 한 번만 노출된다", async () => {
+    const onTempSave = vi.fn().mockResolvedValue({ success: true });
+
+    renderSubmitTalentRegisterHarness({
+      initialValues: createIntegrationValues(),
+      onTempSave,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onTempSave).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledWith("임시 저장되었습니다!");
+  });
+
+  it("임시저장이 실패하면 성공 토스트를 노출하지 않는다", async () => {
+    const onTempSave = vi.fn().mockResolvedValue({ success: false, error: new Error("boom") });
+
+    renderSubmitTalentRegisterHarness({
+      initialValues: createIntegrationValues(),
+      onTempSave,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onTempSave).toHaveBeenCalledTimes(1);
+    expect(showToastMock).not.toHaveBeenCalled();
   });
 });

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  renderSubmitTalentRegisterHarness,
+  createIntegrationValues,
+} from "./submitTalentRegister.integration.helpers";
+import { resetIntegrationMocks, routerPushMock } from "./submitTalentRegister.integration.mocks";
+
+describe("submitTalentRegister integration harness (T1)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+  });
+
+  it("FormProvider 와 TalentRegisterNav 를 최소 하네스로 렌더링한다", () => {
+    renderSubmitTalentRegisterHarness({
+      children: <div>integration section</div>,
+      initialValues: createIntegrationValues(),
+    });
+
+    expect(screen.getByRole("button", { name: "임시 저장" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "작성 완료" })).toBeInTheDocument();
+    expect(screen.getByText("integration section")).toBeInTheDocument();
+  });
+
+  it("뒤로가기 버튼 클릭 시 profile 페이지로 이동한다", async () => {
+    const { user } = renderSubmitTalentRegisterHarness({
+      children: <div>integration section</div>,
+      initialValues: createIntegrationValues(),
+    });
+
+    await user.click(screen.getByRole("button", { name: "이전 페이지" }));
+
+    expect(routerPushMock).toHaveBeenCalledWith("/profile");
+  });
+});

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -10,6 +10,7 @@ import {
   routerPushMock,
   showToastMock,
 } from "./submitTalentRegister.integration.mocks";
+import EducationSection from "../_components/sections/EducationSection";
 
 describe("submitTalentRegister integration harness (T1)", () => {
   beforeEach(() => {
@@ -98,5 +99,86 @@ describe("TalentRegisterNav integration (T2)", () => {
     expect(onTempSave).not.toHaveBeenCalled();
     expect(showToastMock).toHaveBeenCalledTimes(1);
     expect(showToastMock).toHaveBeenLastCalledWith(expect.any(String), "error");
+  });
+});
+
+describe("EducationSection integration (T3)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("첫 임시저장으로 생성된 학력은 reset 이후 다시 임시저장해도 중복 POST 되지 않는다", async () => {
+    const educationsApi = await import("@/lib/api/educations");
+
+    vi.mocked(educationsApi.createEducations).mockResolvedValueOnce([
+      {
+        id: 101,
+        schoolName: "연성대학교",
+        major: "컴퓨터공학",
+        status: "GRADUATED",
+        startDate: "2020-03-01",
+        endDate: "2024-02-01",
+        description: "",
+        degree: "",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    renderSubmitTalentRegisterHarness({
+      children: <EducationSection profileId={1} />,
+      initialValues: createIntegrationValues(),
+      profileId: 1,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "학력 추가" }));
+
+    const schoolNameInputs = screen.getAllByPlaceholderText("학교명을 입력해주세요");
+    const majorInputs = screen.getAllByPlaceholderText("전공을 입력해주세요");
+
+    fireEvent.change(schoolNameInputs[1], { target: { value: "연성대학교" } });
+    fireEvent.change(majorInputs[1], { target: { value: "컴퓨터공학" } });
+
+    fireEvent.change(document.getElementById("educations-1-start-date")!, {
+      target: { value: "2020-03" },
+    });
+    fireEvent.change(document.getElementById("educations-1-end-date")!, {
+      target: { value: "2024-02" },
+    });
+    fireEvent.change(document.getElementById("educations-1-status")!, {
+      target: { value: "GRADUATED" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(educationsApi.createEducations).toHaveBeenCalledTimes(1);
+    expect(educationsApi.createEducations).toHaveBeenCalledWith(1, [
+      {
+        schoolName: "연성대학교",
+        major: "컴퓨터공학",
+        status: "GRADUATED",
+        startDate: "2020-03-01",
+        endDate: "2024-02-01",
+        description: "",
+        degree: "",
+      },
+    ]);
+
+    vi.mocked(educationsApi.createEducations).mockClear();
+    vi.mocked(educationsApi.updateEducation).mockClear();
+    showToastMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(educationsApi.createEducations).not.toHaveBeenCalled();
+    expect(educationsApi.updateEducation).not.toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledWith("임시 저장되었습니다!");
   });
 });

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -1,5 +1,9 @@
+import { act } from "react";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { useFormContext } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TalentRegisterFormValues } from "@/schemas/talent/talentRegisterSchema";
 
 import {
   renderSubmitTalentRegisterHarness,
@@ -11,6 +15,25 @@ import {
   showToastMock,
 } from "./submitTalentRegister.integration.mocks";
 import EducationSection from "../_components/sections/EducationSection";
+
+function JobDirtyFieldsInputs() {
+  const { setValue, watch } = useFormContext<TalentRegisterFormValues>();
+  const role = watch("job.role");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          setValue("job.role", "frontend", { shouldValidate: true, shouldDirty: true });
+        }}
+      >
+        set frontend role
+      </button>
+      <span>{role}</span>
+    </div>
+  );
+}
 
 describe("submitTalentRegister integration harness (T1)", () => {
   beforeEach(() => {
@@ -268,5 +291,84 @@ describe("EducationSection integration (T4)", () => {
 
     expect(screen.getByText("학력 삭제에 실패했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
+  });
+});
+
+describe("jobs dirtyFields integration (T5)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("job 값을 바꾸지 않고 임시저장하면 updateJobs 를 호출하지 않는다", async () => {
+    const jobsApi = await import("@/lib/api/jobs");
+
+    renderSubmitTalentRegisterHarness({
+      children: <JobDirtyFieldsInputs />,
+      initialValues: createIntegrationValues(),
+      profileId: 1,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(jobsApi.updateJobs).not.toHaveBeenCalled();
+  });
+
+  it("job.role 을 변경한 뒤 임시저장하면 role id payload 로 updateJobs 를 호출한다", async () => {
+    const jobsApi = await import("@/lib/api/jobs");
+
+    renderSubmitTalentRegisterHarness({
+      children: <JobDirtyFieldsInputs />,
+      initialValues: createIntegrationValues(),
+      profileId: 1,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "set frontend role" }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(1);
+    expect(jobsApi.updateJobs).toHaveBeenCalledWith(1, { ids: [1] });
+  });
+
+  it("job.role 을 변경한 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 현재 dirty 상태가 유지되어 updateJobs 를 다시 호출한다", async () => {
+    const jobsApi = await import("@/lib/api/jobs");
+
+    renderSubmitTalentRegisterHarness({
+      children: <JobDirtyFieldsInputs />,
+      initialValues: createIntegrationValues(),
+      profileId: 1,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "set frontend role" }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(2);
+    expect(jobsApi.updateJobs).toHaveBeenNthCalledWith(2, 1, { ids: [1] });
   });
 });

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -1,11 +1,15 @@
-import { screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   renderSubmitTalentRegisterHarness,
   createIntegrationValues,
 } from "./submitTalentRegister.integration.helpers";
-import { resetIntegrationMocks, routerPushMock } from "./submitTalentRegister.integration.mocks";
+import {
+  resetIntegrationMocks,
+  routerPushMock,
+  showToastMock,
+} from "./submitTalentRegister.integration.mocks";
 
 describe("submitTalentRegister integration harness (T1)", () => {
   beforeEach(() => {
@@ -32,5 +36,67 @@ describe("submitTalentRegister integration harness (T1)", () => {
     await user.click(screen.getByRole("button", { name: "이전 페이지" }));
 
     expect(routerPushMock).toHaveBeenCalledWith("/profile");
+  });
+});
+
+describe("TalentRegisterNav integration (T2)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("임시저장 버튼을 연속 클릭해도 마지막 클릭 기준 1초 뒤에 저장을 1회만 실행한다", async () => {
+    const onTempSave = vi.fn().mockResolvedValue(undefined);
+    renderSubmitTalentRegisterHarness({
+      initialValues: createIntegrationValues(),
+      onTempSave,
+    });
+
+    const button = screen.getByRole("button", { name: "임시 저장" });
+
+    fireEvent.click(button);
+    await vi.advanceTimersByTimeAsync(900);
+    fireEvent.click(button);
+    await vi.advanceTimersByTimeAsync(999);
+
+    expect(onTempSave).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(onTempSave).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledWith("임시 저장되었습니다!");
+  });
+
+  it("temp-save validation 이 실패하면 저장을 막고 에러 토스트를 띄운다", async () => {
+    const onTempSave = vi.fn().mockResolvedValue(undefined);
+    const invalidValues = createIntegrationValues({
+      educations: [
+        {
+          schoolName: "연성대학교",
+          major: "",
+          status: "" as "" | "ENROLLED" | "GRADUATED" | "COMPLETED",
+          startDate: "",
+          endDate: "",
+          description: "",
+          degree: "",
+        },
+      ],
+    });
+
+    renderSubmitTalentRegisterHarness({
+      initialValues: invalidValues,
+      onTempSave,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onTempSave).not.toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenLastCalledWith(expect.any(String), "error");
   });
 });

--- a/app/dashboard/profile/[profileId]/_actions/__tests__/submitTalentRegister.mocks.ts
+++ b/app/dashboard/profile/[profileId]/_actions/__tests__/submitTalentRegister.mocks.ts
@@ -7,10 +7,12 @@ vi.mock("@/lib/api/profiles", () => ({
 vi.mock("@/lib/api/educations", () => ({
   createEducations: vi.fn().mockResolvedValue([]),
   updateEducation: vi.fn().mockResolvedValue({}),
+  deleteEducation: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/lib/api/experiences", () => ({
   createExperiences: vi.fn().mockResolvedValue([]),
   updateExperience: vi.fn().mockResolvedValue({}),
+  deleteExperience: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/lib/api/languages", () => ({
   createLanguages: vi.fn().mockResolvedValue([]),

--- a/app/dashboard/profile/[profileId]/_components/TalentRegisterNav.tsx
+++ b/app/dashboard/profile/[profileId]/_components/TalentRegisterNav.tsx
@@ -54,7 +54,6 @@ export default function TalentRegisterNav({
         }
 
         await onTempSave();
-        showToast("임시 저장되었습니다!");
       }, 1000);
     }
   };


### PR DESCRIPTION
﻿Closes #9

## 작업 범위
- [x] T1 integration 하네스·공용 mock 스캐폴드
- [x] T2 Nav debounce + 임시저장 validation
- [x] T3 학력 섹션 첫 저장 + reset 후 재저장
- [x] T4 배열 섹션 삭제 + 재저장 흐름
- [x] T5 dirtyFields 기반 저장 흐름 재검증
- [x] T6 토스트·실패 처리 검증
- [x] T7 전체 검증·PR 정리

## 테스트
- npm test -- submitTalentRegister.integration
- npm test -- submitTalentRegister
- npm run type-check

## 리스크·롤백
현재는 Nav/Education/jobs/toast integration 테스트까지 포함합니다. T5에서 job.role 은 reset 이후 keepDirty 때문에 반복 임시저장 시 updateJobs 가 다시 호출되는 현재 계약을 테스트로 고정했습니다. T6에서는 성공 토스트를 page wrapper 한 곳에서만 처리하도록 정리해 중복 성공 토스트와 실패 시 성공 토스트 노출을 막았습니다. 문제 시 각 task 커밋 단위로 revert 가능합니다.
