### PR TITLE
fix: submitTalentRegister 반복 PUT 제거 (#15)

### DIFF
--- a/.plans/submit-talent-register-repeat-put-fix/plan.md
+++ b/.plans/submit-talent-register-repeat-put-fix/plan.md
@@ -1,0 +1,74 @@
+# submitTalentRegister 반복 PUT 제거
+
+## 무엇을 / 왜
+**무엇을**
+
+- 임시저장 성공 후 같은 값으로 다시 임시저장해도 `jobs`, `expTags`의 `PUT`이 반복 호출되지 않도록 프론트 상태 갱신 방식을 수정한다.
+- 이 변경이 실제로 동작함을 `@testing-library/react` 기반 integration 테스트로 증명한다.
+- 기존 배열 섹션의 `reset 후 재저장 시 중복 POST 방지` 계약은 유지되는지 함께 회귀 검증한다.
+
+**왜**
+
+- 현재 `page.tsx`의 임시저장 성공 처리에서 `methods.reset(result.data, { keepDirty: true, ... })`를 사용하고 있다.
+- 동시에 `submitTalentRegister.ts`는 `jobs`, `expTags`를 `dirtyFields` 기준으로 `PUT`할지 판단한다.
+- 이 조합 때문에 한 번 성공적으로 저장된 동일 값이라도, 다음 임시저장에서 다시 `updateJobs`, `updateExpTags`가 호출될 수 있다.
+- 서버가 `PUT`를 멱등하게 처리해야 하는 건 맞지만, 프론트도 불필요한 반복 요청은 줄이는 편이 실무적으로 더 안전하고 깔끔하다.
+
+## 현재 상태 진단
+
+- 반복 `PUT`의 직접 원인
+  - [page.tsx](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/page.tsx:126) 임시저장 성공 후 `reset(..., { keepDirty: true, keepTouched: true, keepErrors: true })`
+  - [submitTalentRegister.ts](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/_actions/submitTalentRegister.ts:196) `jobs`는 `dirtyFields.job.category || dirtyFields.job.role`
+  - [submitTalentRegister.ts](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/_actions/submitTalentRegister.ts:210) `expTags`는 `dirtyFields.job.experiences`
+- 이미 integration 테스트로 현재 계약이 고정되어 있다.
+  - [submitTalentRegister.integration.test.tsx](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx:1)
+  - `jobs`: 두 번째 임시저장에서도 `updateJobs` 재호출
+  - `expTags`: 두 번째 임시저장에서도 `updateExpTags` 재호출
+- 반면 배열 섹션(`education/career/activity/language/certificate`)은 `defaultValues` 비교 기반이라, `reset` 후 재저장에서 중복 `POST`가 나가지 않는 것이 integration으로 확인됐다.
+
+## 해결책
+
+- 1차 후보 해법은 임시저장 성공 후 `reset` 시 `keepDirty: true`를 제거하는 것이다.
+  - 즉, 서버가 받아준 최신 값이 새 `defaultValues`가 되었으면 dirty 상태도 같이 초기화한다.
+  - `keepTouched`, `keepErrors` 유지 여부는 UX를 보며 최소 범위로 판단한다.
+- 이 변경으로 해결되는지 다음 integration 테스트 기대값을 뒤집어 검증한다.
+  - `jobs`: 첫 저장 후 두 번째 임시저장에서 `updateJobs`가 다시 호출되지 않아야 한다.
+  - `expTags`: 첫 저장 후 두 번째 임시저장에서 `updateExpTags`가 다시 호출되지 않아야 한다.
+- 배열 섹션 회귀 테스트는 그대로 유지해, `keepDirty` 제거가 `reset 후 중복 POST 방지`를 깨지 않는지 함께 확인한다.
+- 만약 `keepDirty` 제거가 다른 UX를 깨면, 대안으로 저장 성공한 필드만 선택적으로 dirty 해제하는 방향을 검토한다.
+
+## 트레이드오프
+
+| 선택 | 장점 | 단점 |
+|---|---|---|
+| 성공 후 dirty 전체 해제 | 구현이 단순하고 반복 PUT 원인을 직접 제거한다 | 저장 직후 "수정됨" 표시가 사라져 UX가 달라질 수 있다 |
+| 저장 성공 필드만 선택적으로 dirty 해제 | 영향 범위를 좁힐 수 있다 | RHF 상태 조작이 복잡해지고 유지비가 커진다 |
+| 현재처럼 반복 PUT 허용 | 서버 idempotency에 맡길 수 있다 | 불필요한 네트워크, 로그 노이즈, race 가능성이 남는다 |
+| action 내부에서 값 비교로 중복 PUT 방지 | page reset 정책과 독립적으로 동작할 수 있다 | jobs/expTags만 별도 규칙이 늘어나고 상태 기준이 분산된다 |
+
+## 대안
+
+1. **현재 동작을 유지하고 서버 멱등성만 요구한다**
+   - 기각 이유: 서버가 안전해야 하는 건 맞지만, 프론트도 같은 저장 요청을 계속 보내지 않는 편이 더 낫다.
+2. **Nav 쪽 debounce/in-flight 차단만 강화한다**
+   - 기각 이유: 연타는 막을 수 있어도, "성공 후 다시 저장"에서 발생하는 반복 PUT은 해결하지 못한다.
+3. **`jobs`, `expTags`만 action 내부 값 비교로 따로 막는다**
+   - 기각 이유: 근본 원인은 dirty 상태가 저장 후에도 남는 점이고, 섹션별 예외 규칙이 늘어난다.
+4. **반복 PUT 테스트를 삭제하고 현 계약으로 둔다**
+   - 기각 이유: 이미 현재 동작을 명시적으로 확인했기 때문에, 바꾸기로 하면 테스트 기대값도 함께 바뀌어야 한다.
+
+## 완료 기준
+
+- [ ] fix용 `task.md`가 작성된다
+- [ ] 임시저장 성공 후 dirty 상태 처리 방식이 수정된다
+- [ ] `jobs` 반복 PUT integration 테스트가 "두 번째 저장에서 재호출 없음"으로 바뀌고 통과한다
+- [ ] `expTags` 반복 PUT integration 테스트가 "두 번째 저장에서 재호출 없음"으로 바뀌고 통과한다
+- [ ] 배열 섹션 reset 후 재저장 regression 테스트가 계속 통과한다
+- [ ] `npm test -- submitTalentRegister.integration` 통과
+- [ ] `npm test -- submitTalentRegister` 통과
+- [ ] `npm run type-check` 통과
+- [ ] PR 본문에 "반복 PUT 제거"와 검증 근거가 반영된다
+
+## 다음 단계
+
+이 계획에 사용자가 `진행`이라고 확인하면 `.plans/submit-talent-register-repeat-put-fix/task.md`를 작성한다. task는 먼저 failing integration 테스트 기대값을 뒤집고, 그다음 `page.tsx`의 성공 후 reset 정책을 최소 범위로 수정하는 순서로 쪼갠다.

--- a/.plans/submit-talent-register-repeat-put-fix/task.md
+++ b/.plans/submit-talent-register-repeat-put-fix/task.md
@@ -1,0 +1,22 @@
+# submitTalentRegister 반복 PUT 제거 - task 분할
+
+## Task 1. 임시저장 성공 후 dirty 초기화로 jobs/expTags 반복 PUT 제거
+
+- 목표
+  - 임시저장 성공 후 최신 서버 응답을 `defaultValues`로 반영할 때 `dirtyFields`도 함께 초기화해서, 같은 값으로 다시 임시저장해도 `jobs`, `expTags`의 `PUT`이 반복 호출되지 않게 만든다.
+- 먼저 실패해야 하는 테스트
+  - [app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx)
+  - `jobs dirtyFields integration (T5)`의 "job.role 을 변경한 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 updateJobs 를 다시 호출하지 않는다"
+  - `expTags dirtyFields integration (T12)`의 "job.experiences 를 바꾼 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 updateExpTags 를 다시 호출하지 않는다"
+- 구현 범위
+  - [app/dashboard/profile/[profileId]/page.tsx](/C:/Users/Min/Desktop/lion-connect-frontend/app/dashboard/profile/[profileId]/page.tsx) 의 임시저장 성공 후 `reset` 옵션을 최소 범위로 수정한다.
+  - 필요하면 같은 integration 파일에서 배열 섹션 회귀 기대값을 유지해 `reset` 정책 변경이 기존 계약을 깨지 않았는지 함께 검증한다.
+- 의존성
+  - 없음
+- 완료 기준
+  - `jobs` 반복 PUT integration 테스트가 red -> green 으로 통과한다.
+  - `expTags` 반복 PUT integration 테스트가 red -> green 으로 통과한다.
+  - 배열 섹션의 "reset 후 재저장 시 중복 POST 없음" regression 테스트가 계속 통과한다.
+  - `npm test -- submitTalentRegister.integration` 통과
+  - `npm test -- submitTalentRegister` 통과
+  - `npm run type-check` 통과

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.helpers.tsx
@@ -3,9 +3,14 @@ import "./submitTalentRegister.integration.mocks";
 import type { ReactNode } from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { FormProvider, useForm, type UseFormReturn } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormProvider, useForm, type FieldErrors, type UseFormReturn } from "react-hook-form";
 
-import type { TalentRegisterFormValues } from "@/schemas/talent/talentRegisterSchema";
+import {
+  talentRegisterSchema,
+  type TalentRegisterFormValues,
+} from "@/schemas/talent/talentRegisterSchema";
 import { useToastStore } from "@/store/toastStore";
 
 import { cloneDefaultValues } from "../_actions/__tests__/submitTalentRegister.helpers";
@@ -23,6 +28,7 @@ interface RenderHarnessOptions {
   initialValues?: TalentRegisterFormValues;
   isSubmitDisabled?: boolean;
   onTempSave?: (params: TempSaveHandlerParams) => Promise<unknown> | unknown;
+  onSubmit?: (params: TempSaveHandlerParams) => Promise<unknown> | unknown;
   profileId?: number;
 }
 
@@ -47,10 +53,15 @@ function SubmitTalentRegisterIntegrationHarness({
   initialValues,
   isSubmitDisabled = false,
   onTempSave,
+  onSubmit,
   profileId = 1,
 }: HarnessProps) {
+  const router = useRouter();
   const methods = useForm<TalentRegisterFormValues>({
     defaultValues: initialValues ?? cloneDefaultValues(),
+    resolver: zodResolver(talentRegisterSchema),
+    mode: "onSubmit",
+    shouldFocusError: true,
   });
   const showToast = useToastStore((state) => state.showToast);
 
@@ -68,12 +79,69 @@ function SubmitTalentRegisterIntegrationHarness({
     if (isTempSaveResult(result) && result.success) {
       if (result.data) {
         // page.tsx 와 같은 reset 옵션을 유지해 재저장 흐름을 재현한다.
-        methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true });
+        methods.reset(result.data, { keepTouched: true, keepErrors: true });
       }
       showToast("임시 저장되었습니다!");
     }
 
     return result;
+  };
+
+  const handleSubmit = async (values: TalentRegisterFormValues) => {
+    const result = onSubmit
+      ? await onSubmit({ values, methods, profileId })
+      : await submitTalentRegister({
+          values,
+          methods,
+          profileId,
+        });
+
+    if (isTempSaveResult(result) && result.success) {
+      if (result.data) {
+        methods.reset(result.data);
+      }
+      showToast("인재 프로필이 성공적으로 등록되었습니다!");
+      router.push("/profile");
+    }
+
+    return result;
+  };
+
+  const handleError = (errors: FieldErrors<TalentRegisterFormValues>) => {
+    const getFirstErrorMessage = (value: unknown): string | undefined => {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          const message = getFirstErrorMessage(item);
+          if (message) {
+            return message;
+          }
+        }
+        return undefined;
+      }
+
+      if (typeof value !== "object" || value === null) {
+        return undefined;
+      }
+
+      if ("message" in value && typeof value.message === "string") {
+        return value.message;
+      }
+
+      for (const nestedValue of Object.values(value)) {
+        const message = getFirstErrorMessage(nestedValue);
+        if (message) {
+          return message;
+        }
+      }
+
+      return undefined;
+    };
+
+    const firstMessage = getFirstErrorMessage(errors);
+
+    if (firstMessage) {
+      showToast(firstMessage, "error");
+    }
   };
 
   return (
@@ -83,7 +151,9 @@ function SubmitTalentRegisterIntegrationHarness({
         isSubmitDisabled={isSubmitDisabled}
         onTempSave={handleTempSave}
       />
-      <form id={formId}>{children}</form>
+      <form id={formId} onSubmit={methods.handleSubmit(handleSubmit, handleError)}>
+        {children}
+      </form>
     </FormProvider>
   );
 }
@@ -96,7 +166,14 @@ export function createIntegrationValues(overrides?: Partial<TalentRegisterFormVa
 }
 
 export function renderSubmitTalentRegisterHarness(
-  { children, initialValues, isSubmitDisabled, onTempSave, profileId }: RenderHarnessOptions = {},
+  {
+    children,
+    initialValues,
+    isSubmitDisabled,
+    onTempSave,
+    onSubmit,
+    profileId,
+  }: RenderHarnessOptions = {},
   userOptions?: Parameters<typeof userEvent.setup>[0]
 ) {
   const user = userEvent.setup(userOptions);
@@ -110,6 +187,7 @@ export function renderSubmitTalentRegisterHarness(
         initialValues={initialValues}
         isSubmitDisabled={isSubmitDisabled}
         onTempSave={onTempSave}
+        onSubmit={onSubmit}
         profileId={profileId}
       >
         {children}

--- a/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
+++ b/app/dashboard/profile/[profileId]/__tests__/submitTalentRegister.integration.test.tsx
@@ -61,6 +61,68 @@ function ExpTagsDirtyFieldsInputs() {
   );
 }
 
+function JobResubmitInputs() {
+  const { setValue, watch } = useFormContext<TalentRegisterFormValues>();
+  const role = watch("job.role");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          setValue("job.role", "frontend", { shouldValidate: true, shouldDirty: true });
+        }}
+      >
+        set frontend role
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setValue("job.role", "backend", { shouldValidate: true, shouldDirty: true });
+        }}
+      >
+        set backend role
+      </button>
+      <span>{role}</span>
+    </div>
+  );
+}
+
+function createCompletedIntegrationValues(): TalentRegisterFormValues {
+  return createIntegrationValues({
+    profile: {
+      avatar: null,
+      name: "홍길동",
+      title: "프론트엔드 개발자",
+      phone: "010-1234-5678",
+      email: "hong@example.com",
+      introduction: "사용자 경험을 개선하는 프론트엔드 개발자입니다.",
+      visibility: "PRIVATE",
+    },
+    job: {
+      category: "development",
+      role: "backend",
+      experiences: ["bootcamp"],
+    },
+    educations: [
+      {
+        schoolName: "멋사대학교",
+        major: "컴퓨터공학",
+        status: "GRADUATED",
+        startDate: "2020-03",
+        endDate: "2024-02",
+        description: "",
+        degree: "",
+      },
+    ],
+    portfolio: "https://example.com/portfolio.pdf",
+    portfolioFile: { url: "https://example.com/portfolio.pdf" },
+    workDrivenTest: Object.fromEntries(
+      Array.from({ length: 16 }, (_, index) => [`q${index + 1}`, 3])
+    ) as Record<string, number>,
+  });
+}
+
 describe("submitTalentRegister integration harness (T1)", () => {
   beforeEach(() => {
     resetIntegrationMocks();
@@ -645,7 +707,7 @@ describe("expTags dirtyFields integration (T12)", () => {
     expect(expTagsApi.updateExpTags).toHaveBeenCalledWith(1, { ids: [1, 4] });
   });
 
-  it("job.experiences 를 바꾼 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 현재 dirty 상태가 유지되어 updateExpTags 를 다시 호출한다", async () => {
+  it("job.experiences 를 바꾼 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 updateExpTags 를 다시 호출하지 않는다", async () => {
     const expTagsApi = await import("@/lib/api/expTags");
 
     renderSubmitTalentRegisterHarness({
@@ -670,8 +732,7 @@ describe("expTags dirtyFields integration (T12)", () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
 
-    expect(expTagsApi.updateExpTags).toHaveBeenCalledTimes(2);
-    expect(expTagsApi.updateExpTags).toHaveBeenNthCalledWith(2, 1, { ids: [1, 4] });
+    expect(expTagsApi.updateExpTags).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -724,7 +785,7 @@ describe("jobs dirtyFields integration (T5)", () => {
     expect(jobsApi.updateJobs).toHaveBeenCalledWith(1, { ids: [1] });
   });
 
-  it("job.role 을 변경한 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 현재 dirty 상태가 유지되어 updateJobs 를 다시 호출한다", async () => {
+  it("job.role 을 변경한 뒤 성공적으로 임시저장하면 reset 이후 다시 저장해도 updateJobs 를 다시 호출하지 않는다", async () => {
     const jobsApi = await import("@/lib/api/jobs");
 
     renderSubmitTalentRegisterHarness({
@@ -749,8 +810,67 @@ describe("jobs dirtyFields integration (T5)", () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
 
-    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(2);
-    expect(jobsApi.updateJobs).toHaveBeenNthCalledWith(2, 1, { ids: [1] });
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("final submit after temp save integration (T13)", () => {
+  beforeEach(() => {
+    resetIntegrationMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("임시저장 후 dirty 가 초기화되어도 다시 값을 바꾸면 최종 저장이 zod 검증과 submit 을 정상 처리한다", async () => {
+    const jobsApi = await import("@/lib/api/jobs");
+    const profilesApi = await import("@/lib/api/profiles");
+
+    renderSubmitTalentRegisterHarness({
+      children: <JobResubmitInputs />,
+      initialValues: createCompletedIntegrationValues(),
+      profileId: 1,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "set frontend role" }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "임시 저장" }));
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(1);
+    expect(jobsApi.updateJobs).toHaveBeenLastCalledWith(1, { ids: [1] });
+
+    vi.mocked(jobsApi.updateJobs).mockClear();
+    vi.mocked(profilesApi.updateProfile).mockClear();
+    showToastMock.mockClear();
+    routerPushMock.mockClear();
+    vi.useRealTimers();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "set backend role" }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "작성 완료" }));
+    });
+
+    await waitFor(() => {
+      expect(profilesApi.updateProfile).toHaveBeenCalledTimes(1);
+    });
+
+    const [, profilePayload] = vi.mocked(profilesApi.updateProfile).mock.calls[0];
+
+    expect(profilePayload.status).toBe("COMPLETED");
+    expect(jobsApi.updateJobs).toHaveBeenCalledTimes(1);
+    expect(jobsApi.updateJobs).toHaveBeenCalledWith(1, { ids: [2] });
+    expect(showToastMock).toHaveBeenCalledWith("인재 프로필이 성공적으로 등록되었습니다!");
+    expect(routerPushMock).toHaveBeenCalledWith("/profile");
   });
 });
 

--- a/app/dashboard/profile/[profileId]/page.tsx
+++ b/app/dashboard/profile/[profileId]/page.tsx
@@ -134,7 +134,7 @@ export default function TalentRegisterPage({ params }: { params: Promise<{ profi
       if (result.data) {
         // 임시 저장: 서버에서 받은 전체 데이터(ID 포함)로 reset하여 defaultValues 업데이트
         // 이렇게 해야 다시 임시저장 시 POST가 아닌 PUT이 호출됨
-        methods.reset(result.data, { keepDirty: true, keepTouched: true, keepErrors: true });
+        methods.reset(result.data, { keepTouched: true, keepErrors: true });
       }
       showToast("임시 저장되었습니다!");
     } else {


### PR DESCRIPTION
Closes #15

## 작업 범위
- [x] 임시저장 성공 후 dirty 초기화로 jobs/expTags 반복 PUT 제거
- [x] jobs/expTags 반복 PUT integration 기대값 갱신
- [x] 임시저장 후 다시 값을 바꿔도 최종 저장이 정상 동작하는 integration 회귀 추가

## 테스트
- npm test -- submitTalentRegister.integration
- npm test -- submitTalentRegister
- npm run type-check

## 리스크·롤백
- 저장 직후 dirty 표시 UX가 달라질 수 있습니다.
- 문제 시 커밋 7206d45를 revert 하면 기존 동작으로 롤백됩니다.