### PR TITLE
fix: Vercel production build failures (#23)

### DIFF
--- a/app/(company)/seo/index.ts
+++ b/app/(company)/seo/index.ts
@@ -1,4 +1,10 @@
 import { Metadata } from "next";
+import { normalizeAbsoluteUrl } from "@/lib/normalizeUrl";
+
+const siteUrl = normalizeAbsoluteUrl(
+  process.env.NEXT_PUBLIC_BASE_URL,
+  "https://like-lion.netlify.app"
+);
 
 /**
  * SEO 상수 - 프로젝트 전체에서 사용되는 메타데이터
@@ -26,7 +32,7 @@ export const SEO = {
     "테크 인재",
     "개발자 구인",
   ] as string[],
-  url: process.env.NEXT_PUBLIC_BASE_URL || "https://like-lion.netlify.app",
+  url: siteUrl,
   siteName: "라이언 커넥트",
   locale: "ko_KR" as const,
   type: "website" as const,
@@ -37,7 +43,7 @@ export const SEO = {
   organization: {
     name: "멋쟁이사자처럼",
     foundingDate: "2024",
-    logo: `${process.env.NEXT_PUBLIC_BASE_URL || "https://like-lion.netlify.app"}/logo.png`,
+    logo: `${siteUrl}/logo.png`,
     email: process.env.NEXT_PUBLIC_CONTACT_EMAIL || "contact@lionconnect.com",
     socialLinks: [
       "https://www.instagram.com/likelion.official",

--- a/app/(company)/talents/page.tsx
+++ b/app/(company)/talents/page.tsx
@@ -23,9 +23,7 @@ const EXPERIENCE_BADGE_BY_NAME: Record<string, { label: string; type: BadgeType 
   전공자: { label: "전공자", type: "major" },
 };
 
-export function mapExperiencesToBadges(
-  experiences?: string[]
-): { label: string; type: BadgeType }[] {
+function mapExperiencesToBadges(experiences?: string[]): { label: string; type: BadgeType }[] {
   if (!experiences || experiences.length === 0) return [];
 
   return experiences

--- a/app/api/demo/[...path]/route.ts
+++ b/app/api/demo/[...path]/route.ts
@@ -1,11 +1,11 @@
 import { handleDemoApiRequest } from "@/lib/demo/mockApi";
 
 type DemoRouteContext = {
-  params: Promise<{ path?: string[] }> | { path?: string[] };
+  params: Promise<{ path?: string[] }>;
 };
 
 async function resolvePathSegments(context: DemoRouteContext) {
-  const params = await Promise.resolve(context.params);
+  const params = await context.params;
   return params.path ?? [];
 }
 

--- a/app/dashboard/job-board/[jobId]/opengraph-image.tsx
+++ b/app/dashboard/job-board/[jobId]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { fetchPublicJobPosting } from "@/lib/api/jobPostings";
+import type { JobDetailResponse } from "@/types/job";
 
 export const runtime = "edge";
 export const alt = "채용 공고";
@@ -9,15 +9,32 @@ export const size = {
 };
 export const contentType = "image/png";
 
+type OpenGraphJob = Pick<
+  JobDetailResponse,
+  "companyName" | "employmentType" | "jobRoleName" | "title"
+>;
+
+async function fetchOpenGraphJob(jobId: string): Promise<OpenGraphJob> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.maple109.store/api";
+  const response = await fetch(`${baseUrl}/job-postings/${encodeURIComponent(jobId)}`, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch job posting for opengraph image");
+  }
+
+  return response.json() as Promise<OpenGraphJob>;
+}
+
 export default async function Image({ params }: { params: Promise<{ jobId: string }> }) {
   const { jobId } = await params;
 
   try {
-    const job = await fetchPublicJobPosting(jobId);
+    const job = await fetchOpenGraphJob(jobId);
 
-    // Pretendard 폰트 로드
     const fontData = await fetch(
-      new URL("../../../../public/fonts/PretendardVariable.woff2", import.meta.url)
+      new URL("../../../../public/fonts/SUITE-Regular.woff2", import.meta.url)
     ).then((res) => res.arrayBuffer());
 
     return new ImageResponse(
@@ -59,6 +76,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
               style={{
                 fontSize: "32px",
                 fontWeight: "bold",
+                fontFamily: "SUITE",
                 color: "#FF6B00",
               }}
             >
@@ -70,6 +88,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
           <div
             style={{
               fontSize: "28px",
+              fontFamily: "SUITE",
               color: "#666",
               marginBottom: "16px",
               zIndex: 1,
@@ -83,6 +102,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
             style={{
               fontSize: "56px",
               fontWeight: "bold",
+              fontFamily: "SUITE",
               color: "#1A1A1A",
               lineHeight: 1.2,
               marginBottom: "24px",
@@ -113,6 +133,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
                 padding: "12px 24px",
                 borderRadius: "8px",
                 fontSize: "24px",
+                fontFamily: "SUITE",
               }}
             >
               {job.jobRoleName}
@@ -124,6 +145,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
                 padding: "12px 24px",
                 borderRadius: "8px",
                 fontSize: "24px",
+                fontFamily: "SUITE",
               }}
             >
               {job.employmentType === "FULL_TIME" ? "정규직" : "인턴"}
@@ -137,6 +159,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
               bottom: "60px",
               right: "80px",
               fontSize: "20px",
+              fontFamily: "SUITE",
               color: "#999",
             }}
           >
@@ -148,7 +171,7 @@ export default async function Image({ params }: { params: Promise<{ jobId: strin
         ...size,
         fonts: [
           {
-            name: "Pretendard",
+            name: "SUITE",
             data: fontData,
             style: "normal",
             weight: 400,

--- a/app/dashboard/job-board/[jobId]/opengraph-image.tsx
+++ b/app/dashboard/job-board/[jobId]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { normalizeAbsoluteUrl } from "@/lib/normalizeUrl";
 import type { JobDetailResponse } from "@/types/job";
 
 export const runtime = "edge";
@@ -15,7 +16,10 @@ type OpenGraphJob = Pick<
 >;
 
 async function fetchOpenGraphJob(jobId: string): Promise<OpenGraphJob> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.maple109.store/api";
+  const baseUrl = normalizeAbsoluteUrl(
+    process.env.NEXT_PUBLIC_API_BASE_URL,
+    "https://api.maple109.store/api"
+  );
   const response = await fetch(`${baseUrl}/job-postings/${encodeURIComponent(jobId)}`, {
     cache: "no-store",
   });

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,8 +1,11 @@
 import { MetadataRoute } from "next";
+import { normalizeAbsoluteUrl } from "@/lib/normalizeUrl";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL || "https://like-lion.netlify.app";
+  const baseUrl = normalizeAbsoluteUrl(
+    process.env.NEXT_PUBLIC_BASE_URL,
+    "https://like-lion.netlify.app"
+  );
 
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,12 @@
 import { MetadataRoute } from "next";
 import { fetchPublicJobPostingsServer } from "@/lib/api/serverJobPostings";
+import { normalizeAbsoluteUrl } from "@/lib/normalizeUrl";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://like-lion.netlify.app";
+  const baseUrl = normalizeAbsoluteUrl(
+    process.env.NEXT_PUBLIC_BASE_URL,
+    "https://like-lion.netlify.app"
+  );
 
   // 1. 정적 페이지
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/lib/normalizeUrl.ts
+++ b/lib/normalizeUrl.ts
@@ -1,0 +1,9 @@
+export function normalizeAbsoluteUrl(value: string | undefined, fallback: string) {
+  const rawUrl = (value || fallback).trim().replace(/\/+$/, "");
+
+  if (/^https?:\/\//i.test(rawUrl)) {
+    return rawUrl;
+  }
+
+  return `https://${rawUrl.replace(/^\/+/, "")}`;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix && prettier --write \"**/*.{ts,tsx,json}\"",


### PR DESCRIPTION
Closes #23

## 요약
Vercel 배포를 막던 Next production build 오류와 Edge opengraph image size 제한 초과를 수정했습니다.

## 변경 사항
- `npm run build`가 안정적인 `next build` 경로를 사용하도록 변경했습니다.
- Next page의 invalid named export와 demo route handler 타입 오류를 수정했습니다.
- `opengraph-image` Edge Function에서 큰 Pretendard variable font와 무거운 API wrapper 의존성을 제거했습니다.
- OG route 산출물 크기를 약 820KB 수준으로 줄여 Vercel 1MB 제한 아래로 맞췄습니다.
- Vercel 환경변수에 프로토콜 없는 도메인이 들어와도 build가 실패하지 않도록 공개 URL을 정규화했습니다.

## 검증
- [x] npm run build
- [x] env NEXT_PUBLIC_BASE_URL=lion-connect-demo.vercel.app NEXT_PUBLIC_API_BASE_URL=lion-connect-demo.vercel.app npm run build
- [x] npm run type-check
- [x] npm run lint
- [x] npm test
- [x] npm run start
- [x] curl -I http://localhost:3000
- [x] curl -I http://localhost:3000/demo
- [x] curl -I http://localhost:3000/dashboard/job-board/9001/opengraph-image