### PR TITLE
fix: 데모 이력서 영속화 + 인재탐색 첫 페인트 정리 (#35)

### DIFF
--- a/.plans/demo-store-persistence-and-talents-paint/plan.md
+++ b/.plans/demo-store-persistence-and-talents-paint/plan.md
@@ -1,0 +1,99 @@
+# 데모 스토어 영속화 + 인재탐색 첫 페인트 정리
+
+> Level 3 / 점수 10/12. 본 문서는 1단계(상위 계획)이며 사용자 "진행" 승인 전까지 파일 수정 금지.
+> 승인 후 `seed.yaml` + `task.md` 작성 → 재승인 → 구현.
+
+## 무엇을 / 왜
+
+데모 모드에서 이력서 수정 결과가 새로고침/페이지 이동마다 기본값(홍길동)과 수정값 사이를 오가고(#2, #4),
+공개 토글이 인재탐색에 늦게 반영되며(#3), `/talents` 첫 페인트에서 Footer가 떴다가 스켈레톤이 끼어들며
+레이아웃이 점프한다(#1). 사용자가 신뢰할 수 있는 데모가 되도록 4가지를 함께 고친다.
+
+## 현재 상태 진단
+
+### 공통 근본 원인 (#2, #4, #3 일부) — 서버 인메모리 스토어가 인스턴스 간 공유되지 않음
+- `lib/demo/resumeStore.ts`, `lib/demo/roleStore.ts`는 모듈 레벨 변수에 상태를 둔다.
+  - `let store = buildStore();` (resumeStore.ts:81)
+  - `let store = clone(demoRoleSeed);` (roleStore.ts:107)
+- 클라이언트는 `lib/apiClient.ts`에서 `fetch('/api/demo/...')` → `app/api/demo/[...path]/route.ts`
+  → `handleDemoApiRequest`(mockApi.ts)로 이 모듈 스토어를 변형한다.
+- `next.config.ts`에 `output: 'standalone'`/`runtime` 지정이 없고 단일 상주 서버 흔적도 없음 → 기본 서버리스(다중 인스턴스) 배포로 추정.
+- 결과: PUT(수정)은 인스턴스 A의 store를, 이후 GET(조회)은 인스턴스 B의 store(아직 시드=홍길동)를 읽는다.
+  새로고침마다 라우팅되는 인스턴스가 달라져 **값이 왔다갔다(#2)**, 목록으로 오면 시드로 되돌아간다(#4).
+  사용자의 "초기화를 계속 하는 것 같다"는 직관이 사실상 정확함(인스턴스마다 `buildStore()`로 재시드).
+- #3도 같은 뿌리: `listDemoTalents`/상세는 `getDemoResumeSnapshot(visibility !== "PUBLIC" → 제외)`(roleStore.ts:554,591)을
+  읽는데, 토글이 기록된 인스턴스와 인재탐색을 읽는 인스턴스가 다르면 반영이 지연된다.
+
+### #3 추가 원인 — React Query 캐시 stale-while-revalidate
+- `useTalents`는 `staleTime: 0`이라 마운트 시 재요청하지만, 직전 캐시값을 먼저 그려 "이전 값 보였다가 반영"이 된다.
+- 공개 토글 mutation(`app/dashboard/profile/page.tsx:48`)은 `["profile","list",userId]`만 무효화하고
+  `["talents", ...]` 캐시는 건드리지 않는다.
+
+### #1 — `/talents` Suspense fallback 부재로 인한 Footer 플래시 + 점프
+- `app/(company)/talents/page.tsx`의 `<Suspense>`에 **fallback이 없다**(page.tsx:242). `TalentsPageContent`는 `useSearchParams`로 서스펜드된다.
+- `app/(company)/layout.tsx`는 `<div className="pt-20">{children}</div><Footer />` 구조라
+  서스펜드 동안 children이 비어 Footer가 위로 올라왔다가, 스켈레톤 마운트 시 아래로 밀린다.
+- 콘텐츠 영역에 높이 예약(min-height)도 없다.
+
+## 해결책 (3–5)
+
+1. **데모 데이터 계층을 브라우저 단일 소스로 영속화** — `isDemoRequest`이고 브라우저 환경이면 `apiClient`에서
+   `fetch('/api/demo')` 대신 `handleDemoApiRequest`를 클라이언트에서 직접 디스패치하고, 변경마다 영속화.
+   첫 접근 시 저장소가 비었을 때만 시드로 1회 초기화 → "초기화는 한 번만"(#4 요구) 충족, 인스턴스 의존 제거(#2/#4 해소).
+   서버 `/api/demo` 라우트는 SSR/비브라우저 폴백으로 유지(첫 페인트는 시드로 충분).
+2. **저장소를 데이터 종류별로 분리** — 용량/특성에 맞게 둘로 나눈다.
+   - **구조화 JSON 상태 → localStorage**: 이력서/역할 텍스트 상태(이름·공개여부·경력 등). 수 KB라 5MB 한계 안전.
+     실제 버그(#2/#4)의 원인이 전부 여기. `resumeStore`/`roleStore`에 `hydrate()`/`persist()` 경계를 만들어 JSON 동기화.
+   - **업로드 바이너리 → IndexedDB**: 현재 `resumeStore`의 `uploadedFiles: Map<string, {body: ArrayBuffer}>`(presign 업로드 파일).
+     Blob 그대로 IndexedDB에 저장(대용량/새로고침 후 유지). localStorage에는 절대 넣지 않음.
+   - **시드 이미지/PDF는 저장 대상 아님**: `resumeSeed.ts`는 정적 URL(`/demo/...`)을 참조할 뿐 바이너리를 store에 담지 않음.
+   - 두 스토어 간 단방향 의존(roleStore→resumeStore snapshot)은 유지.
+3. **#3 캐시 무효화** — 공개 토글 `onSuccess`에서 `["talents"]`도 invalidate. 클라 스토어가 즉시 일관되므로
+   인재탐색 복귀 시 stale 오값 대신 바로 정확값으로 수렴.
+4. **#1 첫 페인트** — `<Suspense fallback={<스켈레톤 동일 레이아웃>}>` 지정 + 콘텐츠 래퍼에 min-height 예약으로
+   Footer 점프/플래시 제거.
+5. **회귀 방지 테스트** — 영속 라운드트립(수정→재읽기 동일값), 시드 1회 초기화, 토글 후 인재탐색 즉시 반영,
+   talents Suspense fallback 렌더를 단위/통합 테스트로 고정.
+
+## 트레이드오프
+
+- **클라 영속화 vs 데모 단순성**: 데모 로직이 브라우저로 이동하며 SSR과 클라 데이터가 갈릴 수 있음(첫 페인트는 시드, 이후 localStorage).
+  → 데모는 단일 사용자라 허용 가능. 첫 페인트 시드는 의도된 동작으로 문서화.
+- **localStorage 영속 vs 리셋 편의**: 영속되면 데모를 "초기 상태로 보고 싶을 때" 리셋 수단이 필요.
+  → `resetDemoResumeStore`/`resetDemoRoleStore`를 localStorage + IndexedDB 클리어까지 확장하고, 필요 시 데모 헤더/쿼리파라미터 리셋 진입점 고려(task에서 결정).
+- **localStorage(JSON) + IndexedDB(바이너리) 분리 vs 단일 저장소**: 저장소가 둘로 나뉘어 hydrate/persist 경로가 두 갈래가 됨.
+  → 용량·특성상 불가피(localStorage는 Blob 부적합, 5MB 한계). 경계를 얇은 어댑터로 감싸 복잡도 국소화.
+- **#3 invalidate vs 스켈레톤 재노출**: `["talents"]` 무효화 시 짧은 스켈레톤이 보일 수 있음(오값보다는 나음).
+  → 클라 스토어 즉시성 덕에 재요청이 매우 빨라 체감 최소.
+
+## 대안 (각 기각 이유 포함)
+
+- **대안 A: 서버 영속(Vercel KV/Redis)** — 인스턴스 공유 문제 자체를 서버에서 해결.
+  - 기각: 포트폴리오 데모에 외부 의존성/비용/네트워크 지연 추가. 단일 사용자엔 과함.
+- **대안 B: 쿠키에 데모 상태 저장** — 서버 라우트 유지하며 인스턴스 무관 영속.
+  - 기각: 이력서 전체 데이터는 쿠키 4KB 한계 초과. 매 요청 직렬화 비용.
+- **대안 C: #2/#4를 두고 #1/#3만 수정(RQ 캐시·UI만)** — 범위 축소.
+  - 기각: 근본(인스턴스 비공유)을 남기면 수정값 소실이 계속됨. 사용자가 "진짜 큰 오류"로 지목한 #2 미해결.
+- **대안 D: 단일 상주 서버(`output: standalone` + 노드 호스팅)** — 모듈 스토어가 자연히 영속.
+  - 기각: 배포 인프라 변경이 더 큰 리스크. 새로고침 시 프로세스 재시작/스케일아웃에 여전히 취약.
+
+## 완료 기준 (DoD)
+
+- [ ] 이력서 인적사항(이름) 수정 후 새로고침 N회 반복해도 항상 수정값 표시(#2). 시드값으로 되돌아가지 않음.
+- [ ] 수정→작성 완료→목록 이동 시 수정값 유지(#4). 시드 초기화는 최초 1회만 발생.
+- [ ] 공개 토글 후 기업 인재탐색 진입 시 이전 값 노출 없이 즉시 정확 상태 반영(#3).
+- [ ] `/talents` 새로고침 시 Footer가 먼저 떴다가 밀리는 점프/플래시 없음(#1). 첫 페인트부터 스켈레톤 자리 고정.
+- [ ] 데모 리셋 경로로 초기 상태 복원 가능.
+- [ ] 신규/수정 테스트 통과, 기존 `lib/demo/__tests__/*` 회귀 없음, lint/tsc 통과(`wsl bash -lc`).
+- [ ] 검증은 `.agents/evaluation.md` Stage 1/2/3 + `.agents/drift.md` 확인.
+
+## 검증 전략 (개요)
+
+- 단위: 영속 라운드트립/시드 1회/리셋 (stores), 토글 invalidate (mutation).
+- 통합: profile 수정→재조회 동일값, 토글→talents 반영 (jsdom/localStorage mock).
+- 수동: dev에서 #1 시각 확인(Footer 비점프), #2/#4 새로고침 반복.
+
+## 미해결/확인 필요 (승인 시 함께 결정)
+
+- 배포 타깃이 실제 서버리스인지 최종 확인(README/배포 설정 추가 확認). 단, 클라 영속화는 배포 형태와 무관하게 안전.
+- 데모 리셋 UX 진입점 위치(헤더 메뉴 vs 쿼리파라미터) — task 단계에서 확정.

--- a/.plans/demo-store-persistence-and-talents-paint/seed.yaml
+++ b/.plans/demo-store-persistence-and-talents-paint/seed.yaml
@@ -1,0 +1,53 @@
+goal: >
+  데모 모드 이력서 데이터를 브라우저 단일 소스로 영속화하여 새로고침/페이지 이동 시
+  수정값이 보존되도록 하고(#2/#4), 공개 토글이 인재탐색에 즉시 반영되며(#3),
+  /talents 첫 페인트의 Footer 점프/플래시를 제거한다(#1).
+  구조화 JSON 상태는 localStorage, 업로드 바이너리는 IndexedDB에 저장한다.
+
+risk_level: "Level 3"
+
+ambiguity_score: 0.15  # 증상/원인 명확. 업로드 서빙 메커니즘(SW)이 유일한 불확실 지점 → 별도 task로 격리.
+
+constraints:
+  - "비데모(실서버 API) 경로의 동작과 계약은 변경하지 않는다."
+  - "데모 데이터 shape(ProfileResponse 등 타입)은 변경하지 않는다."
+  - "서버 /api/demo 라우트는 SSR/비브라우저 폴백으로 유지한다(삭제 금지)."
+  - "구조화 JSON은 localStorage, 업로드 Blob은 IndexedDB. 이미지를 localStorage에 base64로 넣지 않는다."
+  - "데모 시드 초기화는 저장소가 비었을 때 최초 1회만 수행한다."
+  - "두 스토어 간 단방향 의존(roleStore -> resumeStore snapshot)을 유지한다(순환 의존 금지)."
+  - "wsl bash -lc 로 npm/tsc/test 실행(UNC 경로 에러 회피)."
+  - "--no-verify 훅 우회 금지. main 직접 커밋/push 금지."
+
+acceptance_criteria:
+  - "이력서 이름 수정 후 새로고침 다회 반복해도 항상 수정값 표시(#2). 시드값 복귀 없음."
+  - "수정 -> 작성 완료 -> 목록 이동 시 수정값 유지(#4). 시드 초기화는 최초 1회만."
+  - "공개 토글 후 기업 인재탐색 진입 시 이전 값 노출 없이 즉시 정확 상태 반영(#3)."
+  - "/talents 새로고침 시 Footer 선노출/점프/플래시 없음. 첫 페인트부터 스켈레톤 자리 고정(#1)."
+  - "업로드한 이미지/포트폴리오가 새로고침 후에도 표시됨(IndexedDB 영속)."
+  - "데모 리셋 경로로 localStorage + IndexedDB 초기화 가능."
+  - "기존 lib/demo/__tests__/* 회귀 없음. 신규 영속/캐시/UI 테스트 통과. tsc/lint 통과."
+
+non_goals:
+  - "실서버(api.maple109.store) 연동/계약 변경."
+  - "인증/권한 로직 변경."
+  - "데모 데이터 모델/시드 콘텐츠 확장."
+  - "비데모 사용자 경험 변경."
+  - "PWA 전체 도입(SW는 /api/demo/uploads/* 서빙 용도로만 국소 사용)."
+
+mechanical_gates:
+  - "wsl bash -lc 'npm run type-check'"
+  - "wsl bash -lc 'npm run lint'"
+  - "wsl bash -lc 'npm test'"
+
+drift_triggers:
+  - "계획 외 파일/도메인 수정(비데모 apiClient 분기, 실서버 코드 등)"
+  - "데모 데이터 타입/shape 변경"
+  - "acceptance criteria 재해석"
+  - "새 dependency 추가(SW는 무의존 직접 작성)"
+  - "업로드 서빙을 SW 대신 다른 메커니즘으로 변경"
+
+approval_required_when:
+  - "drift score가 임계값 이상"
+  - "seed의 goal/constraints/acceptance_criteria 변경 필요"
+  - "non_goals에 포함된 작업이 필요해짐"
+  - "업로드 서빙 메커니즘을 SW에서 변경하거나, 업로드 영속을 포기(서버 폴백 유지)해야 할 때"

--- a/.plans/demo-store-persistence-and-talents-paint/task.md
+++ b/.plans/demo-store-persistence-and-talents-paint/task.md
@@ -155,6 +155,9 @@ T4 -> T7(업로드 IndexedDB + SW)
 
 ## T7 - 업로드 바이너리 IndexedDB 영속 + SW 서빙
 
+> 상태: **후속 PR로 분리(사용자 승인 2026-06-12)**. T1~T6가 보고된 버그(#1~#4)를 모두 해결하므로
+> 이 PR에서는 제외한다. 업로드는 현재 서버 라우트 폴스루로 동작(회귀 없음). 별도 이슈에서 SW로 영속화.
+
 **보장할 동작**
 - 업로드한 이미지/포트폴리오가 새로고침 후에도 표시. `/api/demo/uploads/*` 요청을 Service Worker가 IndexedDB에서 서빙(컴포넌트 변경 없이 `<img src>` 동작).
 - SW 미지원/실패 시 서버 라우트 폴백으로 graceful degrade.
@@ -176,6 +179,8 @@ T4 -> T7(업로드 IndexedDB + SW)
 ---
 
 ## T8 - 통합 검증 + 회귀 + 평가
+
+> 스코프: T1~T6 한정(T7 제외). T7 영속 검증은 후속 PR에서 수행.
 
 **보장할 동작**
 - acceptance_criteria 전 항목 통과. evaluation Stage 1/2/3 + drift 확인.

--- a/.plans/demo-store-persistence-and-talents-paint/task.md
+++ b/.plans/demo-store-persistence-and-talents-paint/task.md
@@ -1,0 +1,194 @@
+# 데모 스토어 영속화 + 인재탐색 첫 페인트 정리 - Task 분할
+
+> 원칙: 각 task는 1개 커밋 단위. TDD(실패 테스트 → green → refactor).
+> plan: [plan.md](./plan.md) / seed: [seed.yaml](./seed.yaml)
+
+## 본 작업의 스코프
+
+- 포함:
+  - 데모 JSON 상태 localStorage 영속 (resumeStore / roleStore)
+  - 브라우저에서 데모 API 클라이언트 디스패치 (`/api/demo/uploads/*` 제외, 폴스루)
+  - #3 공개 토글 시 `["talents"]` 캐시 무효화
+  - #1 `/talents` Suspense fallback + 높이 예약
+  - 데모 리셋 경로 확장 (localStorage + IndexedDB)
+  - 업로드 바이너리 IndexedDB 영속 + Service Worker 서빙(`/api/demo/uploads/*`)
+- 미포함:
+  - 실서버 API/계약, 인증/권한, 데모 데이터 모델 변경
+  - 비데모 경로 동작 변경
+
+## 의존성 순서
+
+```text
+T1(#1 UI) ─ 독립, 먼저 분리
+T2(영속 어댑터) -> T3(stores hydrate/persist) -> T4(apiClient 클라 디스패치) -> T5(#3 캐시 무효화)
+                                              -> T6(리셋 경로 확장)
+T4 -> T7(업로드 IndexedDB + SW)
+모든 T -> T8(통합 검증)
+```
+
+> T1은 다른 task와 독립(순수 UI). 가장 먼저 커밋해 리스크를 줄인다.
+> 핵심 버그(#2/#3/#4)는 T2~T6에서 해결된다. T7(업로드)은 분리되어 있어 단독 실패해도 #1~#4에 영향 없음.
+
+---
+
+## T1 - /talents 첫 페인트 Footer 점프 제거 (#1)
+
+**보장할 동작**
+- `/talents` 새로고침 시 Footer가 먼저 떴다가 스켈레톤에 밀려 내려가지 않는다. 첫 프레임부터 스켈레톤 영역 높이 고정.
+
+**선행 테스트 / 선행 검증**
+- `app/(company)/talents/__tests__/page.suspense.test.tsx`(신규): Suspense fallback 렌더 시 스켈레톤(3장) + 헤더가 보이고, 콘텐츠 영역이 비어있지 않음을 assert.
+
+**작업**
+- `app/(company)/talents/page.tsx`의 `<Suspense>`에 로딩 스켈레톤과 동일 레이아웃 fallback 지정(현 `isLoading` 분기 마크업을 공용 컴포넌트로 추출해 재사용).
+- 콘텐츠 래퍼에 min-height 예약(스켈레톤/빈상태/데이터 전환 시 Footer 위치 고정). layout의 `pt-20` + Footer 구조와 충돌 없는 값 사용.
+
+**완료 기준**
+- 수동: dev에서 강한 새로고침 반복 시 Footer 점프 없음.
+- 신규 테스트 green, 기존 회귀 없음.
+
+**커밋**
+- `fix: prevent footer jump on talents first paint (#1)`
+
+---
+
+## T2 - 데모 영속 어댑터 추가 (localStorage JSON / IndexedDB Blob 경계)
+
+**보장할 동작**
+- 얇은 어댑터로 JSON(localStorage)과 Blob(IndexedDB) 영속을 캡슐화. SSR/비브라우저에서는 no-op(시드 동작 유지).
+
+**선행 테스트 / 선행 검증**
+- `lib/demo/__tests__/demoPersistence.test.ts`(신규): JSON set/get 라운드트립, 키 네임스페이스, 브라우저 미감지 시 no-op, IndexedDB put/get(블롭) 모킹.
+
+**작업**
+- `lib/demo/persistence.ts`(신규):
+  - `loadDemoJson<T>(key)` / `saveDemoJson(key, value)` (localStorage, try/catch, 용량초과 graceful).
+  - `putDemoBlob(objectKey, blob)` / `getDemoBlob(objectKey)` / `clearDemoBlobs()` (IndexedDB, 무의존 직접 구현).
+  - `isBrowser()` 가드.
+
+**완료 기준**
+- 신규 테스트 green. tsc/lint 통과. 다른 파일 미수정.
+
+**커밋**
+- `feat: add demo persistence adapter (localStorage + indexeddb)`
+
+---
+
+## T3 - resumeStore / roleStore hydrate·persist 연결 (JSON 영속)
+
+**보장할 동작**
+- 스토어 변경 시 localStorage에 직렬화, 첫 접근 시 저장값으로 hydrate. 저장값 없을 때만 시드 1회.
+
+**선행 테스트 / 선행 검증**
+- `lib/demo/__tests__/resumeStore.persist.test.ts`(신규): 프로필 이름 수정 → persist → 새 모듈 로드(hydrate) → 수정값 유지. 저장소 비면 시드.
+- `roleStore` 동일 패턴 1케이스(공개여부 변경 후 hydrate 일관).
+
+**작업**
+- `lib/demo/resumeStore.ts`: `buildStore()` 전 hydrate 시도, 변경 함수에서 persist 호출(또는 mutation 래퍼 1곳에 집약). `resetDemoResumeStore`가 저장소도 클리어.
+- `lib/demo/roleStore.ts`: 동일하게 hydrate/persist. roleStore→resumeStore 단방향 유지.
+
+**완료 기준**
+- 신규/기존 테스트 green. 시드 1회 보장.
+
+**커밋**
+- `feat: persist demo resume/role stores to localStorage`
+
+---
+
+## T4 - 브라우저에서 데모 API 클라이언트 디스패치 (uploads 폴스루)
+
+**보장할 동작**
+- 브라우저 + `isDemoRequest`이면 `fetch('/api/demo')` 대신 `handleDemoApiRequest`를 클라에서 호출 → 단일 소스(localStorage)로 일관. `/api/demo/uploads/*`는 실 fetch로 폴스루(서버 서빙 유지, T7 전 회귀 방지).
+
+**선행 테스트 / 선행 검증**
+- `lib/__tests__/apiClient.demo.client.test.ts`(신규): 데모 PUT(이름 수정) → 직후 GET이 수정값 반환(네트워크 미경유, 단일 메모리/localStorage). `/uploads` 경로는 fetch로 위임됨을 assert.
+
+**작업**
+- `lib/apiClient.ts`: `isDemoRequest && isBrowser && !path.startsWith('/api/demo/uploads')`이면 `Request` 구성 후 `handleDemoApiRequest(request, segments)` 호출, 응답을 동일 파이프라인으로 처리. 데모 API 로그 기록 유지.
+- `handleDemoApiRequest`/mockApi import가 클라 번들에서 안전한지 확인(서버 전용 API 미사용).
+
+**완료 기준**
+- 신규 테스트 green. 비데모 경로 영향 없음(기존 apiClient 테스트 green).
+
+**커밋**
+- `feat: dispatch demo api on client for store consistency`
+
+---
+
+## T5 - 공개 토글 시 인재탐색 캐시 즉시 반영 (#3)
+
+**보장할 동작**
+- 공개/비공개 토글 성공 시 `["talents"]` 캐시 무효화 → 인재탐색 복귀 시 이전 값 노출 없이 정확 상태.
+
+**선행 테스트 / 선행 검증**
+- `app/dashboard/profile/__tests__/togglePublic.invalidate.test.tsx`(신규): 토글 onSuccess가 `["profile","list",userId]`와 `["talents"]` 모두 invalidate 호출.
+
+**작업**
+- `app/dashboard/profile/page.tsx`의 `togglePublicMutation.onSuccess`에 `queryClient.invalidateQueries({ queryKey: ["talents"] })` 추가.
+
+**완료 기준**
+- 신규 테스트 green. 수동: 토글 후 /talents 진입 시 즉시 반영.
+
+**커밋**
+- `fix: invalidate talents cache on resume visibility toggle (#3)`
+
+---
+
+## T6 - 데모 리셋 경로 확장 (localStorage + IndexedDB)
+
+**보장할 동작**
+- `resetDemoResumeStore`/`resetDemoRoleStore`가 메모리뿐 아니라 localStorage + IndexedDB까지 초기화.
+
+**선행 테스트 / 선행 검증**
+- `lib/demo/__tests__/demoReset.test.ts`(신규): 수정 → reset → hydrate 시 시드값 복귀, IndexedDB 비워짐.
+
+**작업**
+- 리셋 함수에서 영속 어댑터 clear 호출. 데모 리셋 진입점(쿼리파라미터 vs 헤더 메뉴)은 본 task에서 최소 1개 확정 후 연결.
+
+**완료 기준**
+- 신규 테스트 green. 리셋 후 초기 상태 복원 확인.
+
+**커밋**
+- `feat: reset demo persistence (localStorage + indexeddb)`
+
+---
+
+## T7 - 업로드 바이너리 IndexedDB 영속 + SW 서빙
+
+**보장할 동작**
+- 업로드한 이미지/포트폴리오가 새로고침 후에도 표시. `/api/demo/uploads/*` 요청을 Service Worker가 IndexedDB에서 서빙(컴포넌트 변경 없이 `<img src>` 동작).
+- SW 미지원/실패 시 서버 라우트 폴백으로 graceful degrade.
+
+**선행 테스트 / 선행 검증**
+- `lib/demo/__tests__/uploadPersistence.test.ts`(신규): 업로드 PUT → IndexedDB 저장 → GET 조회 시 동일 blob. SW 등록 로직 단위 검증(가능 범위).
+
+**작업**
+- T4의 폴스루 해제: `/api/demo/uploads/*` PUT/GET도 클라 디스패치 → `storeDemoUpload`/`getDemoUpload`가 IndexedDB 사용.
+- `public/demo-sw.js`(무의존) + 등록 유틸: 데모 모드에서만 등록, `/api/demo/uploads/*` fetch 가로채 IndexedDB 서빙.
+- presign/complete 흐름이 IndexedDB 경로와 일관되는지 점검.
+
+**완료 기준**
+- 신규 테스트 green. 수동: 썸네일 교체 → 새로고침 → 이미지 유지. SW 실패 시 깨지지 않음.
+
+**커밋**
+- `feat: persist and serve demo uploads via indexeddb + service worker`
+
+---
+
+## T8 - 통합 검증 + 회귀 + 평가
+
+**보장할 동작**
+- acceptance_criteria 전 항목 통과. evaluation Stage 1/2/3 + drift 확인.
+
+**선행 테스트 / 선행 검증**
+- 통합 시나리오(jsdom + localStorage/IndexedDB mock): 이름 수정→재조회 동일(#2/#4), 토글→talents 반영(#3).
+
+**작업**
+- 전체 `npm run type-check / lint / test`(wsl bash -lc).
+- `.agents/evaluation.md` Stage 1/2/3, `.agents/drift.md` 기록. 미검증 항목 사유 PR 본문에 명시.
+
+**완료 기준**
+- 모든 mechanical_gates green. acceptance_criteria 체크 완료.
+
+**커밋**
+- `test: integration coverage for demo persistence and first paint`

--- a/app/(company)/talents/_components/IntroduceCardSkeleton.tsx
+++ b/app/(company)/talents/_components/IntroduceCardSkeleton.tsx
@@ -1,6 +1,9 @@
 export default function IntroduceCardSkeleton() {
   return (
-    <section className="mx-auto mb-6 rounded-2xl bg-white p-8">
+    <section
+      data-testid="introduce-card-skeleton"
+      className="mx-auto mb-6 rounded-2xl bg-white p-8"
+    >
       <div className="inline-flex justify-start items-center gap-12">
         {/* 왼쪽: 프로필 스켈레톤 */}
         <div className="w-40 inline-flex flex-col justify-start items-start gap-8">

--- a/app/(company)/talents/_components/TalentsLoadingState.tsx
+++ b/app/(company)/talents/_components/TalentsLoadingState.tsx
@@ -1,0 +1,35 @@
+import IntroduceCardSkeleton from "./IntroduceCardSkeleton";
+
+/**
+ * 인재탐색 첫 페인트용 로딩 상태.
+ * - Suspense fallback과 데이터 로딩(isLoading) 양쪽에서 동일 레이아웃을 재사용한다.
+ * - useSearchParams 등 라우터 훅에 의존하지 않아 Suspense fallback에서 재서스펜드되지 않는다.
+ * - min-h-screen으로 콘텐츠 높이를 예약해 Footer가 먼저 떴다가 밀리는 점프(#1)를 막는다.
+ */
+export default function TalentsLoadingState() {
+  return (
+    <main data-testid="talents-loading" className="w-full text-black mt-8 min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section className="mb-8 space-y-4">
+          {/* 검색/필터 헤더 자리 (정적 스켈레톤) */}
+          <div className="w-full" aria-hidden>
+            <div className="flex w-full h-14 gap-3">
+              <div className="flex-1 rounded-xl bg-neutral-200 animate-pulse" />
+              <div className="w-20 rounded-xl bg-neutral-200 animate-pulse" />
+            </div>
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="h-10 w-72 rounded-lg bg-neutral-200 animate-pulse" />
+              <div className="h-5 w-20 rounded bg-neutral-200 animate-pulse" />
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-12">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <IntroduceCardSkeleton key={index} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/(company)/talents/_components/__tests__/TalentsLoadingState.test.tsx
+++ b/app/(company)/talents/_components/__tests__/TalentsLoadingState.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TalentsLoadingState from "@/app/(company)/talents/_components/TalentsLoadingState";
+
+describe("TalentsLoadingState", () => {
+  it("헤더 자리와 3개의 스켈레톤 카드를 렌더해 첫 페인트부터 콘텐츠 영역을 채운다", () => {
+    render(<TalentsLoadingState />);
+
+    expect(screen.getByTestId("talents-loading")).toBeInTheDocument();
+    expect(screen.getAllByTestId("introduce-card-skeleton")).toHaveLength(3);
+  });
+
+  it("콘텐츠 영역 높이를 예약해 Footer 점프를 막는다", () => {
+    render(<TalentsLoadingState />);
+
+    expect(screen.getByTestId("talents-loading")).toHaveClass("min-h-screen");
+  });
+
+  it("useSearchParams 등 라우터 훅에 의존하지 않아 Suspense fallback에서 재서스펜드되지 않는다", () => {
+    // next/navigation 컨텍스트(mock) 없이도 렌더가 성공해야 한다.
+    expect(() => render(<TalentsLoadingState />)).not.toThrow();
+  });
+});

--- a/app/(company)/talents/page.tsx
+++ b/app/(company)/talents/page.tsx
@@ -7,7 +7,7 @@ import Pager from "@/components/Pager";
 import TalentSearchHeader from "./_components/TalentSearchHeader";
 import EmptyTalentState from "./_components/EmptyTalentState";
 import IntroduceCard from "./[talentId]/_components/IntroduceCard";
-import IntroduceCardSkeleton from "./_components/IntroduceCardSkeleton";
+import TalentsLoadingState from "./_components/TalentsLoadingState";
 import { useTalents } from "@/hooks/company/useTalents";
 import type { BadgeType } from "@/components/ui/badge";
 import { JOB_ROLE_ID_BY_NAME, findJobGroupByJobName } from "@/constants/jobs";
@@ -95,20 +95,7 @@ function TalentsPageContent() {
 
   // 로딩 중이거나 데이터가 아직 없는 경우 스켈레톤 표시
   if (isLoading || !data) {
-    return (
-      <main className="w-full text-black mt-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <section className="mb-8 space-y-4">
-            <TalentSearchHeader totalCount={0} />
-            <div className="mt-6 flex flex-col gap-12">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <IntroduceCardSkeleton key={index} />
-              ))}
-            </div>
-          </section>
-        </div>
-      </main>
-    );
+    return <TalentsLoadingState />;
   }
 
   // 에러 상태 처리
@@ -239,7 +226,7 @@ function TalentsPageContent() {
  */
 export default function TalentsPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<TalentsLoadingState />}>
       <TalentsPageContent />
     </Suspense>
   );

--- a/app/dashboard/profile/__tests__/togglePublicInvalidate.test.tsx
+++ b/app/dashboard/profile/__tests__/togglePublicInvalidate.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// #3: 공개 토글 성공 시 인재탐색(talents) 캐시도 무효화되어야 한다.
+
+const updateProfileMock = vi.fn().mockResolvedValue({});
+
+vi.mock("@/hooks/talent/queries/useMyProfiles", () => ({
+  useMyProfiles: () => ({
+    data: [
+      {
+        id: 1,
+        name: "홍길동",
+        title: "프론트엔드 포트폴리오 이력서",
+        introduction: "소개",
+        storageUrl: "/demo/profile-demo.png",
+        likelihoodCode: null,
+        visibility: "PUBLIC",
+        status: "COMPLETED",
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/lib/api/profiles", () => ({
+  updateProfile: (...args: unknown[]) => updateProfileMock(...args),
+  createEmptyProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+}));
+
+vi.mock("@/hooks/common/useDebounce", () => ({
+  useDebounce: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
+
+vi.mock("@/contexts/ConfirmContext", () => ({
+  useConfirm: () => vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import ProfilePage from "@/app/dashboard/profile/page";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("이력서 공개 토글", () => {
+  it("토글 성공 시 profile.list와 talents 캐시를 모두 무효화한다 (#3)", async () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProfilePage />
+      </QueryClientProvider>
+    );
+
+    // PUBLIC 상태 → "공개 중" 버튼 클릭 (PRIVATE 전환은 confirm 없이 진행)
+    fireEvent.click(screen.getByRole("button", { name: "공개 중" }));
+
+    await waitFor(() => {
+      expect(updateProfileMock).toHaveBeenCalledTimes(1);
+    });
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+    expect(invalidatedKeys).toContainEqual(["talents"]);
+    expect(invalidatedKeys.some((key) => key[0] === "profile" && key[1] === "list")).toBe(true);
+  });
+});

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -51,6 +51,8 @@ function ProfilePage() {
     onSuccess: () => {
       showToast("공개 설정이 변경되었습니다.");
       queryClient.invalidateQueries({ queryKey: ["profile", "list", userId] });
+      // #3: 인재탐색 목록도 즉시 갱신되도록 무효화 (이전 공개 상태가 잠깐 보이는 문제 방지)
+      queryClient.invalidateQueries({ queryKey: ["talents"] });
     },
     onError: () => {
       showToast("공개 설정 변경에 실패했습니다.", "error");

--- a/app/demo/reset/page.tsx
+++ b/app/demo/reset/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { resetAllDemoData } from "@/lib/demo/reset";
+
+function safeReturnTo(value: string | null) {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+/**
+ * 데모 데이터를 초기 시드 상태로 되돌린 뒤 홈(또는 returnTo)으로 이동한다.
+ * localStorage(JSON) + IndexedDB(업로드 blob)를 모두 비운다.
+ */
+export default function DemoResetPage() {
+  const searchParams = useSearchParams();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const destination = safeReturnTo(searchParams.get("returnTo")) ?? "/";
+
+    resetAllDemoData()
+      .then(() => {
+        if (!isMounted) return;
+        // 인메모리 스토어까지 시드로 다시 채우도록 전체 새로고침으로 이동한다.
+        window.location.assign(destination);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setErrorMessage("데모 데이터를 초기화하지 못했습니다.");
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [searchParams]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-neutral-50 px-4">
+      <section
+        className="w-full max-w-sm rounded-lg border border-neutral-200 bg-white p-6 text-center shadow-sm"
+        aria-live="polite"
+      >
+        <p className="text-sm font-semibold text-brand-05">LionConnect Demo</p>
+        <h1 className="mt-2 font-title text-xl font-bold text-neutral-900">
+          데모 데이터를 초기화하고 있습니다
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-neutral-600">
+          수정한 이력서와 업로드 파일을 처음 상태로 되돌린 뒤 이동합니다.
+        </p>
+        {errorMessage ? (
+          <p className="mt-4 text-sm font-semibold text-red-600">{errorMessage}</p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/e2e/portfolio-demo.spec.ts
+++ b/e2e/portfolio-demo.spec.ts
@@ -25,14 +25,10 @@ test.describe("portfolio demo mode", () => {
   });
 
   test("enters talent demo and records browser API traffic", async ({ page }) => {
-    const profileResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/demo/profile/me?profileId=1") && response.status() === 200
-    );
-
+    // 데모 API는 브라우저에서 로컬 디스패치되므로 네트워크 응답을 기다리지 않고,
+    // 로드된 UI와 Demo API 로그(클라이언트 기록)로 검증한다.
     await page.goto("/demo/enter/talent?returnTo=/dashboard/profile/1");
     await expect(page).toHaveURL(/\/dashboard\/profile\/1$/);
-    await profileResponse;
 
     await expectDemoHeader(page, "인재 데모");
     await expect(page.getByPlaceholder("이력서 제목")).toBeVisible();
@@ -43,28 +39,16 @@ test.describe("portfolio demo mode", () => {
   });
 
   test("allows company demo access to the protected talent search route", async ({ page }) => {
-    const talentSearchResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/demo/profiles/search") && response.status() === 200
-    );
-
     await page.goto("/demo/enter/company?returnTo=/talents");
     await expect(page).toHaveURL(/\/talents$/);
-    await talentSearchResponse;
 
     await expectDemoHeader(page, "기업 데모");
     await expect(page.getByText(/총\s+\d+명/)).toBeVisible();
   });
 
   test("allows admin demo access to the protected admin route", async ({ page }) => {
-    const inquiriesResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/api/demo/admin/inquiries") && response.status() === 200
-    );
-
     await page.goto("/demo/enter/admin?returnTo=/admin/inquiries");
     await expect(page).toHaveURL(/\/admin\/inquiries$/);
-    await inquiriesResponse;
 
     await expectDemoHeader(page, "관리자 데모");
     await expect(page.getByText("담당자명")).toBeVisible();

--- a/lib/__tests__/apiClient.demoClient.test.ts
+++ b/lib/__tests__/apiClient.demoClient.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// 데모 모드 강제 활성화
+vi.mock("@/lib/demoMode", () => ({
+  isDemoAuthState: () => true,
+}));
+
+import { get, put } from "@/lib/apiClient";
+import { resetDemoResumeStore } from "@/lib/demo/resumeStore";
+
+const profileBody = {
+  name: "홍길동222",
+  title: "프론트엔드 포트폴리오 이력서",
+  introduction: "수정된 소개",
+  storageUrl: "/demo/profile-demo.png",
+  visibility: "PUBLIC" as const,
+  status: "COMPLETED" as const,
+};
+
+describe("apiClient 데모 클라이언트 디스패치", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetDemoResumeStore();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("데모 요청은 네트워크(fetch) 없이 로컬 디스패치되어 단일 소스로 일관된다", async () => {
+    const fetchSpy = vi.fn(() => {
+      throw new Error("네트워크가 호출되면 안 된다");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await put("/profile/me?profileId=1", profileBody);
+    const profile = await get<{ name: string }>("/profile/me?profileId=1");
+
+    expect(profile.name).toBe("홍길동222");
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("/uploads 경로는 서버 라우트로 폴스루(fetch)된다", async () => {
+    const fetchSpy = vi.fn(
+      async (..._args: Parameters<typeof fetch>) => new Response(null, { status: 204 })
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await put("/uploads/demo/profile-1/x.png", { ignored: true });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = String(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl).toContain("/api/demo/uploads/");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/lib/__tests__/apiClient.test.ts
+++ b/lib/__tests__/apiClient.test.ts
@@ -9,10 +9,23 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// 데모 모드 판정을 테스트별로 제어한다.
+// 기본은 비데모(false)라서 fetch 전송/응답 처리 경로를 그대로 검증할 수 있고,
+// 데모 전용 테스트에서만 true로 바꿔 브라우저 로컬 디스패치(#2/#4) 동작을 검증한다.
+vi.mock("@/lib/demoMode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/demoMode")>();
+  return { ...actual, isDemoAuthState: vi.fn(() => false) };
+});
+
 import { get, ApiError } from "@/lib/apiClient";
+import { isDemoAuthState } from "@/lib/demoMode";
 import { DEMO_AUTH_PROFILES } from "@/constants/demoAuth";
 import { useDemoApiLogStore } from "@/store/demoApiLogStore";
 import { useAuthStore } from "@/store/authStore";
+import { resetDemoResumeStore } from "@/lib/demo/resumeStore";
+
+const mockedIsDemo = vi.mocked(isDemoAuthState);
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -35,6 +48,9 @@ function emptyOkResponse(): Response {
 
 describe("apiClient — 기본 동작", () => {
   beforeEach(() => {
+    mockedIsDemo.mockReturnValue(false);
+    localStorage.clear();
+    resetDemoResumeStore();
     useAuthStore.setState({ accessToken: "access-token", user: null });
     useDemoApiLogStore.getState().clearEntries();
   });
@@ -42,6 +58,7 @@ describe("apiClient — 기본 동작", () => {
   afterEach(() => {
     useAuthStore.setState({ accessToken: null, user: null });
     useDemoApiLogStore.getState().clearEntries();
+    vi.restoreAllMocks();
   });
 
   it("200 JSON 응답을 그대로 반환한다", async () => {
@@ -103,26 +120,30 @@ describe("apiClient — 기본 동작", () => {
     expect(headers.Authorization).toBe("Bearer access-token");
   });
 
-  it("demo auth state에서는 상대 endpoint를 /api/demo으로 보내고 로그를 기록한다", async () => {
+  it("demo 상대 endpoint는 네트워크 없이 로컬 디스패치되고 로그를 기록한다", async () => {
+    mockedIsDemo.mockReturnValue(true);
     useAuthStore.setState({
       accessToken: DEMO_AUTH_PROFILES.demo_talent.accessToken,
       user: DEMO_AUTH_PROFILES.demo_talent.user,
     });
-    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const fetchMock = vi.spyOn(global, "fetch");
 
-    await get("/profile/me");
+    const result = await get<{ name: string }>("/profile/me?profileId=1");
 
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/demo/profile/me");
+    // 데모 스토어(시드)에서 직접 응답 → fetch 미호출
+    expect(result.name).toBe("홍길동");
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(useDemoApiLogStore.getState().entries).toMatchObject([
       {
         method: "GET",
-        path: "/api/demo/profile/me",
+        path: "/api/demo/profile/me?profileId=1",
         status: 200,
       },
     ]);
   });
 
-  it("demo auth state에서도 절대 URL은 /api/demo으로 바꾸지 않는다", async () => {
+  it("demo auth state에서도 절대 URL은 /api/demo으로 바꾸지 않고 네트워크로 보낸다", async () => {
+    mockedIsDemo.mockReturnValue(true);
     useAuthStore.setState({
       accessToken: DEMO_AUTH_PROFILES.demo_talent.accessToken,
       user: DEMO_AUTH_PROFILES.demo_talent.user,

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -12,9 +12,12 @@ import {
   API_ERROR_MESSAGES,
   HTTP_STATUS,
   API_ENDPOINTS,
+  DEMO_API_BASE_PATH,
   resolveApiRequestUrl,
 } from "@/constants/api";
 import { isDemoAuthState } from "@/lib/demoMode";
+import { isBrowser } from "@/lib/demo/persistence";
+import { handleDemoApiRequest } from "@/lib/demo/mockApi";
 import { recordDemoApiLog } from "@/store/demoApiLogStore";
 import { useAuthStore } from "@/store/authStore";
 
@@ -40,6 +43,35 @@ type RequestOptions = RequestInit & {
 
 // 리프레시 토큰 요청 중복 방지를 위한 Promise 캐싱
 let refreshPromise: Promise<string> | null = null;
+
+/**
+ * 데모 모드 요청을 브라우저에서 직접 디스패치한다.
+ * - 서버리스 인스턴스 의존을 제거하고 localStorage 단일 소스로 일관성을 보장한다(#2/#4).
+ * - 업로드 바이너리(/api/demo/uploads/*)는 서버 라우트로 폴스루한다(T7에서 SW로 전환).
+ */
+function shouldDispatchDemoLocally(isDemoRequest: boolean, url: string): boolean {
+  return isDemoRequest && isBrowser() && !url.startsWith(`${DEMO_API_BASE_PATH}/uploads`);
+}
+
+async function dispatchDemoLocally(
+  url: string,
+  options: RequestOptions,
+  headers: Record<string, string>
+): Promise<Response> {
+  const absolute = new URL(url, "http://demo.local");
+  const segments = absolute.pathname
+    .replace(/^\/api\/demo\/?/, "")
+    .split("/")
+    .filter(Boolean);
+
+  const request = new Request(absolute.toString(), {
+    method: options.method ?? "GET",
+    headers,
+    body: options.body as BodyInit | null | undefined,
+  });
+
+  return handleDemoApiRequest(request, segments);
+}
 
 /**
  * 타임아웃 기능이 있는 fetch 래퍼
@@ -237,12 +269,14 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
   }
 
   try {
-    // 요청 전송
-    const response = await fetchWithTimeout(url, {
-      ...options,
-      headers,
-      credentials: options.skipCredentials ? "omit" : "include", // 조건부 credentials
-    });
+    // 요청 전송 (데모는 브라우저에서 로컬 디스패치, 그 외/업로드는 네트워크)
+    const response = shouldDispatchDemoLocally(isDemoRequest, url)
+      ? await dispatchDemoLocally(url, options, headers)
+      : await fetchWithTimeout(url, {
+          ...options,
+          headers,
+          credentials: options.skipCredentials ? "omit" : "include", // 조건부 credentials
+        });
 
     if (isDemoRequest) {
       recordDemoApiLog({

--- a/lib/demo/__tests__/demoPersistence.test.ts
+++ b/lib/demo/__tests__/demoPersistence.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDemoBlobs,
+  getDemoBlob,
+  isBrowser,
+  loadDemoJson,
+  putDemoBlob,
+  removeDemoJson,
+  saveDemoJson,
+} from "@/lib/demo/persistence";
+
+describe("demo persistence - JSON (localStorage)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("브라우저(jsdom) 환경을 감지한다", () => {
+    expect(isBrowser()).toBe(true);
+  });
+
+  it("없는 키는 null을 반환한다", () => {
+    expect(loadDemoJson("resume")).toBeNull();
+  });
+
+  it("save 후 load 라운드트립이 성립한다", () => {
+    saveDemoJson("resume", { name: "홍길동222", count: 3 });
+    expect(loadDemoJson<{ name: string; count: number }>("resume")).toEqual({
+      name: "홍길동222",
+      count: 3,
+    });
+  });
+
+  it("remove 후에는 null을 반환한다", () => {
+    saveDemoJson("resume", { a: 1 });
+    removeDemoJson("resume");
+    expect(loadDemoJson("resume")).toBeNull();
+  });
+
+  it("setItem이 실패해도(용량 초과 등) 예외를 던지지 않는다", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    expect(() => saveDemoJson("resume", { big: "x" })).not.toThrow();
+  });
+
+  it("손상된 JSON은 null로 폴백한다", () => {
+    localStorage.setItem("demo:resume", "{not-json");
+    expect(loadDemoJson("resume")).toBeNull();
+  });
+});
+
+describe("demo persistence - Blob (indexeddb / in-memory fallback)", () => {
+  beforeEach(async () => {
+    await clearDemoBlobs();
+  });
+
+  it("put 후 get 라운드트립이 성립한다", async () => {
+    const blob = new Blob(["hello"], { type: "text/plain" });
+    await putDemoBlob("demo/profile-1/x.png", blob);
+
+    const loaded = await getDemoBlob("demo/profile-1/x.png");
+    expect(loaded).not.toBeNull();
+    expect(loaded?.type).toBe("text/plain");
+    expect(await loaded?.text()).toBe("hello");
+  });
+
+  it("없는 키는 null을 반환한다", async () => {
+    expect(await getDemoBlob("missing")).toBeNull();
+  });
+
+  it("clear 후에는 모든 blob이 비워진다", async () => {
+    await putDemoBlob("a", new Blob(["a"]));
+    await clearDemoBlobs();
+    expect(await getDemoBlob("a")).toBeNull();
+  });
+});

--- a/lib/demo/__tests__/demoReset.test.ts
+++ b/lib/demo/__tests__/demoReset.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updatedProfile = {
+  name: "홍길동222",
+  title: "프론트엔드 포트폴리오 이력서",
+  introduction: "수정된 소개",
+  storageUrl: "/demo/profile-demo.png",
+  visibility: "PUBLIC" as const,
+  status: "COMPLETED" as const,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("resetAllDemoData", () => {
+  it("리셋 후 모듈 재로드 시 이력서가 시드(홍길동)로 복원된다", async () => {
+    vi.resetModules();
+    const resume1 = await import("@/lib/demo/resumeStore");
+    resume1.updateDemoProfile(1, updatedProfile);
+    resume1.persistResumeStore();
+    expect(resume1.getDemoProfile(1).name).toBe("홍길동222");
+
+    const reset = await import("@/lib/demo/reset");
+    await reset.resetAllDemoData();
+
+    vi.resetModules();
+    const resume2 = await import("@/lib/demo/resumeStore");
+    expect(resume2.getDemoProfile(1).name).toBe("홍길동");
+  });
+
+  it("리셋은 IndexedDB 업로드 blob도 비운다", async () => {
+    vi.resetModules();
+    const persistence = await import("@/lib/demo/persistence");
+    await persistence.putDemoBlob("demo/profile-1/x.png", new Blob(["x"]));
+    expect(await persistence.getDemoBlob("demo/profile-1/x.png")).not.toBeNull();
+
+    const reset = await import("@/lib/demo/reset");
+    await reset.resetAllDemoData();
+
+    expect(await persistence.getDemoBlob("demo/profile-1/x.png")).toBeNull();
+  });
+});

--- a/lib/demo/__tests__/storePersistence.test.ts
+++ b/lib/demo/__tests__/storePersistence.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #2/#4 회귀 방지: 데모 스토어가 "새 서버 인스턴스(모듈 재로드)" 후에도
+ * localStorage에서 hydrate되어 수정값을 유지하는지 검증한다.
+ * vi.resetModules()로 서버리스 콜드스타트/인스턴스 교체를 시뮬레이션한다.
+ */
+
+function demoReq(method: string, path: string, body?: unknown) {
+  return new Request(`http://localhost/api/demo${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function segmentsOf(path: string) {
+  return path.split("?")[0].split("/").filter(Boolean);
+}
+
+async function freshApi() {
+  vi.resetModules();
+  return import("@/lib/demo/mockApi");
+}
+
+const updatedProfile = {
+  name: "홍길동222",
+  title: "프론트엔드 포트폴리오 이력서",
+  introduction: "수정된 소개",
+  storageUrl: "/demo/profile-demo.png",
+  visibility: "PUBLIC" as const,
+  status: "COMPLETED" as const,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("데모 스토어 영속화 (resumeStore)", () => {
+  it("저장소가 비면 시드(홍길동)로 시작한다", async () => {
+    const api = await freshApi();
+    const res = await api.handleDemoApiRequest(
+      demoReq("GET", "/profile/me?profileId=1"),
+      segmentsOf("/profile/me")
+    );
+    expect((await res.json()).name).toBe("홍길동");
+  });
+
+  it("이름 수정이 모듈 재로드(새 인스턴스) 후에도 유지된다 (#2/#4)", async () => {
+    const api1 = await freshApi();
+    const putRes = await api1.handleDemoApiRequest(
+      demoReq("PUT", "/profile/me?profileId=1", { ...updatedProfile, name: "홍길동222" }),
+      segmentsOf("/profile/me")
+    );
+    expect(putRes.status).toBe(200);
+
+    const api2 = await freshApi();
+    const getRes = await api2.handleDemoApiRequest(
+      demoReq("GET", "/profile/me?profileId=1"),
+      segmentsOf("/profile/me")
+    );
+    expect((await getRes.json()).name).toBe("홍길동222");
+  });
+
+  it("비공개 전환이 재로드 후 인재탐색에 반영된다 (#3 cross-store)", async () => {
+    const api1 = await freshApi();
+    await api1.handleDemoApiRequest(
+      demoReq("PUT", "/profile/me?profileId=1", { ...updatedProfile, visibility: "PRIVATE" }),
+      segmentsOf("/profile/me")
+    );
+
+    const api2 = await freshApi();
+    const searchRes = await api2.handleDemoApiRequest(
+      demoReq("GET", "/profiles/search"),
+      segmentsOf("/profiles/search")
+    );
+    const body = await searchRes.json();
+    const names = (body.content ?? []).map((t: { name: string }) => t.name);
+    expect(names).not.toContain("홍길동222");
+    expect(names).not.toContain("홍길동");
+  });
+});
+
+describe("데모 스토어 영속화 primitive", () => {
+  it("resumeStore persist/hydrate 라운드트립", async () => {
+    vi.resetModules();
+    const mod1 = await import("@/lib/demo/resumeStore");
+    mod1.updateDemoProfile(1, updatedProfile);
+    mod1.persistResumeStore();
+
+    vi.resetModules();
+    const mod2 = await import("@/lib/demo/resumeStore");
+    expect(mod2.getDemoProfile(1).name).toBe("홍길동222");
+  });
+
+  it("roleStore persist/hydrate 라운드트립", async () => {
+    vi.resetModules();
+    const mod1 = await import("@/lib/demo/roleStore");
+    const created = mod1.createDemoCompanyJobPosting({
+      title: "영속 테스트 공고",
+      jobRoleId: 0,
+      employmentType: "FULL_TIME",
+      workplace: "서울",
+      jobDescription: "",
+      mainTasks: "",
+      requirements: "",
+      preferred: "",
+      benefits: "",
+      hiringProcess: "",
+      status: "DRAFT",
+      images: [],
+    } as never);
+    mod1.persistRoleStore();
+
+    vi.resetModules();
+    const mod2 = await import("@/lib/demo/roleStore");
+    const list = mod2.listDemoCompanyJobPostings(new URLSearchParams());
+    const titles = (list.content ?? []).map((j: { title: string }) => j.title);
+    expect(titles).toContain("영속 테스트 공고");
+    expect(created.jobPostingId).toBeGreaterThan(0);
+  });
+});

--- a/lib/demo/mockApi.ts
+++ b/lib/demo/mockApi.ts
@@ -40,6 +40,7 @@ import {
   updateDemoLanguage,
   updateDemoProfile,
   upsertDemoProfileLinks,
+  persistResumeStore,
 } from "@/lib/demo/resumeStore";
 import {
   applyDemoJob,
@@ -69,6 +70,7 @@ import {
   updateDemoCompanyJobPosting,
   updateDemoTalentThumbnail,
   updateDemoInquiryStatus,
+  persistRoleStore,
 } from "@/lib/demo/roleStore";
 import type {
   ImageUploadCompleteRequest,
@@ -99,6 +101,17 @@ type DemoHandlerContext = {
 
 function jsonResponse(body: unknown, status = 200) {
   return Response.json(body, { status });
+}
+
+/**
+ * 변경(non-GET) 요청이 성공하면 두 스토어를 localStorage에 직렬화한다.
+ * 서버/클라이언트 디스패치 공용 choke point. 서버(SSR)에서는 영속이 no-op이다.
+ */
+function persistAfterMutation(method: string, response: Response) {
+  if (method === "GET") return;
+  if (response.status >= 400) return;
+  persistResumeStore();
+  persistRoleStore();
 }
 
 function noContentResponse() {
@@ -635,18 +648,16 @@ export async function handleDemoApiRequest(request: Request, pathSegments: strin
       }
     }
 
-    const profileResponse = await handleProfileRoutes(context);
-    if (profileResponse) return profileResponse;
+    const response =
+      (await handleProfileRoutes(context)) ??
+      (await handleRolePageRoutes(context)) ??
+      (segments[0] === "profile"
+        ? ((await handleArraySectionRoutes(context)) ?? (await handleChoiceSectionRoutes(context)))
+        : null);
 
-    const rolePageResponse = await handleRolePageRoutes(context);
-    if (rolePageResponse) return rolePageResponse;
-
-    if (segments[0] === "profile") {
-      const arraySectionResponse = await handleArraySectionRoutes(context);
-      if (arraySectionResponse) return arraySectionResponse;
-
-      const choiceSectionResponse = await handleChoiceSectionRoutes(context);
-      if (choiceSectionResponse) return choiceSectionResponse;
+    if (response) {
+      persistAfterMutation(context.method, response);
+      return response;
     }
 
     return errorResponse(`No demo API handler for ${context.method} ${path}`, 404);

--- a/lib/demo/persistence.ts
+++ b/lib/demo/persistence.ts
@@ -1,0 +1,138 @@
+/**
+ * 데모 모드 영속 어댑터.
+ * - 구조화 JSON 상태 → localStorage (작고 동기적, 5MB 한계 안전)
+ * - 업로드 바이너리(Blob) → IndexedDB (대용량, 새로고침 후 유지)
+ * - SSR/비브라우저/테스트 등 저장소 미가용 시 안전하게 no-op 또는 in-memory 폴백한다.
+ *
+ * 이력서 데이터 shape나 비데모 경로에는 영향을 주지 않는다.
+ */
+
+const JSON_PREFIX = "demo:";
+
+export function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function hasLocalStorage(): boolean {
+  try {
+    return typeof localStorage !== "undefined" && localStorage !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function loadDemoJson<T>(key: string): T | null {
+  if (!hasLocalStorage()) return null;
+  try {
+    const raw = localStorage.getItem(JSON_PREFIX + key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDemoJson<T>(key: string, value: T): void {
+  if (!hasLocalStorage()) return;
+  try {
+    localStorage.setItem(JSON_PREFIX + key, JSON.stringify(value));
+  } catch {
+    // 용량 초과/직렬화 실패 시 무시 (데모 동작 우선)
+  }
+}
+
+export function removeDemoJson(key: string): void {
+  if (!hasLocalStorage()) return;
+  try {
+    localStorage.removeItem(JSON_PREFIX + key);
+  } catch {
+    // ignore
+  }
+}
+
+/* ================================
+ * Blob 저장 (IndexedDB / in-memory 폴백)
+ * ================================ */
+
+const DB_NAME = "demo-uploads";
+const DB_VERSION = 1;
+const STORE_NAME = "blobs";
+
+/** IndexedDB 미가용 환경(SSR/jsdom 등)에서 사용하는 폴백. */
+let memoryBlobs: Map<string, Blob> | null = null;
+function getMemoryBlobs(): Map<string, Blob> {
+  if (!memoryBlobs) memoryBlobs = new Map();
+  return memoryBlobs;
+}
+
+function hasIndexedDb(): boolean {
+  try {
+    return typeof indexedDB !== "undefined" && indexedDB !== null;
+  } catch {
+    return false;
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function withStore<T>(
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, mode);
+        const store = tx.objectStore(STORE_NAME);
+        const request = run(store);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        tx.oncomplete = () => db.close();
+      })
+  );
+}
+
+export async function putDemoBlob(objectKey: string, blob: Blob): Promise<void> {
+  if (!hasIndexedDb()) {
+    getMemoryBlobs().set(objectKey, blob);
+    return;
+  }
+  try {
+    await withStore("readwrite", (store) => store.put(blob, objectKey));
+  } catch {
+    getMemoryBlobs().set(objectKey, blob);
+  }
+}
+
+export async function getDemoBlob(objectKey: string): Promise<Blob | null> {
+  if (!hasIndexedDb()) {
+    return getMemoryBlobs().get(objectKey) ?? null;
+  }
+  try {
+    const result = await withStore<Blob | undefined>("readonly", (store) => store.get(objectKey));
+    return result ?? null;
+  } catch {
+    return getMemoryBlobs().get(objectKey) ?? null;
+  }
+}
+
+export async function clearDemoBlobs(): Promise<void> {
+  getMemoryBlobs().clear();
+  if (!hasIndexedDb()) return;
+  try {
+    await withStore("readwrite", (store) => store.clear());
+  } catch {
+    // ignore
+  }
+}

--- a/lib/demo/reset.ts
+++ b/lib/demo/reset.ts
@@ -1,0 +1,15 @@
+import { resetDemoResumeStore } from "@/lib/demo/resumeStore";
+import { resetDemoRoleStore } from "@/lib/demo/roleStore";
+import { clearDemoBlobs } from "@/lib/demo/persistence";
+
+/**
+ * 데모 모드의 모든 영속 상태를 초기 시드로 되돌린다.
+ * - 인메모리 스토어 재빌드 + localStorage(JSON) 제거
+ * - IndexedDB 업로드 blob 비우기
+ * 데모를 처음 상태로 보고 싶을 때 사용한다(/demo/reset).
+ */
+export async function resetAllDemoData(): Promise<void> {
+  resetDemoResumeStore();
+  resetDemoRoleStore();
+  await clearDemoBlobs();
+}

--- a/lib/demo/resumeStore.ts
+++ b/lib/demo/resumeStore.ts
@@ -1,6 +1,7 @@
 import { findJobRoleById } from "@/constants/jobMapping";
 import { EXP_TAG_ID_MAP } from "@/lib/expTags/map";
 import { demoResumeSeed, DEMO_RESUME_NOW, type DemoProfileRecord } from "@/lib/demo/resumeSeed";
+import { isBrowser, loadDemoJson, removeDemoJson, saveDemoJson } from "@/lib/demo/persistence";
 import type {
   AwardRequest,
   AwardResponse,
@@ -78,8 +79,44 @@ function buildStore(): DemoResumeStore {
   };
 }
 
-let store = buildStore();
+const RESUME_STORE_KEY = "resume-store";
+const RESUME_STORE_VERSION = 1;
+
+type PersistedResumeStore = { version: number; data: DemoResumeStore };
+
+/**
+ * 브라우저에서는 localStorage에 저장된 데모 스토어로 hydrate한다.
+ * 저장값이 없거나 버전이 다르면 시드로 빌드하고 최초 1회 저장한다(#4: 초기화는 한 번만).
+ * SSR/비브라우저에서는 항상 시드로 빌드(영속 no-op).
+ */
+function loadOrBuildStore(): DemoResumeStore {
+  if (isBrowser()) {
+    const saved = loadDemoJson<PersistedResumeStore>(RESUME_STORE_KEY);
+    if (saved && saved.version === RESUME_STORE_VERSION && saved.data) {
+      return saved.data;
+    }
+  }
+  const built = buildStore();
+  if (isBrowser()) {
+    saveDemoJson<PersistedResumeStore>(RESUME_STORE_KEY, {
+      version: RESUME_STORE_VERSION,
+      data: built,
+    });
+  }
+  return built;
+}
+
+let store = loadOrBuildStore();
 const uploadedFiles = new Map<string, { body: ArrayBuffer; contentType: string }>();
+
+/** 현재 스토어 상태를 localStorage에 직렬화한다(브라우저 한정). */
+export function persistResumeStore() {
+  if (!isBrowser()) return;
+  saveDemoJson<PersistedResumeStore>(RESUME_STORE_KEY, {
+    version: RESUME_STORE_VERSION,
+    data: store,
+  });
+}
 
 function now() {
   return new Date().toISOString();
@@ -163,6 +200,9 @@ function deleteSectionItem<T extends DemoSectionItem>(
 export function resetDemoResumeStore() {
   store = buildStore();
   uploadedFiles.clear();
+  if (isBrowser()) {
+    removeDemoJson(RESUME_STORE_KEY);
+  }
 }
 
 /**

--- a/lib/demo/roleStore.ts
+++ b/lib/demo/roleStore.ts
@@ -12,6 +12,7 @@ import {
 } from "@/constants/jobMapping";
 import { getDemoResumeSnapshot } from "@/lib/demo/resumeStore";
 import { applyResumeToTalentDetail, applyResumeToTalentListItem } from "@/lib/demo/talentAdapter";
+import { isBrowser, loadDemoJson, removeDemoJson, saveDemoJson } from "@/lib/demo/persistence";
 import type {
   AdminCompaniesResponse,
   AdminUsersResponse,
@@ -104,13 +105,41 @@ function paged<T>(items: T[], page: number, size: number) {
   };
 }
 
-let store: DemoRoleSeed = clone(demoRoleSeed);
+const ROLE_STORE_KEY = "role-store";
+const ROLE_STORE_VERSION = 1;
+
+type PersistedRoleStore = { version: number; data: DemoRoleSeed };
+
+function loadOrBuildRoleStore(): DemoRoleSeed {
+  if (isBrowser()) {
+    const saved = loadDemoJson<PersistedRoleStore>(ROLE_STORE_KEY);
+    if (saved && saved.version === ROLE_STORE_VERSION && saved.data) {
+      return saved.data;
+    }
+  }
+  const built = clone(demoRoleSeed);
+  if (isBrowser()) {
+    saveDemoJson<PersistedRoleStore>(ROLE_STORE_KEY, { version: ROLE_STORE_VERSION, data: built });
+  }
+  return built;
+}
+
+let store: DemoRoleSeed = loadOrBuildRoleStore();
 
 /** 인재 데모 이력서(resumeStore profile id=1)와 매칭되는 인재 탐색 talent id. */
 const RESUME_TALENT_ID = 1;
 
+/** 현재 역할 스토어 상태를 localStorage에 직렬화한다(브라우저 한정). */
+export function persistRoleStore() {
+  if (!isBrowser()) return;
+  saveDemoJson<PersistedRoleStore>(ROLE_STORE_KEY, { version: ROLE_STORE_VERSION, data: store });
+}
+
 export function resetDemoRoleStore() {
   store = clone(demoRoleSeed);
+  if (isBrowser()) {
+    removeDemoJson(ROLE_STORE_KEY);
+  }
 }
 
 function now() {


### PR DESCRIPTION
Closes #35

## 요약
데모 모드 이력서 수정값이 새로고침/이동마다 시드로 되돌아가고(#2/#4), 공개 토글이 인재탐색에 늦게 반영되며(#3), /talents 첫 페인트에서 Footer 점프가 발생(#1)하던 문제를 해결한다. 근본 원인은 **서버 인메모리 데모 스토어가 서버리스 인스턴스 간 공유되지 않는 것**으로, 데모 데이터를 브라우저 단일 소스(JSON: localStorage)로 영속화하고 모든 데모 API를 브라우저에서 로컬 디스패치한다.

상세 계획: .plans/demo-store-persistence-and-talents-paint/

## 변경 사항 (task 단위)
- [x] T1: /talents Suspense fallback + 높이 예약으로 Footer 점프 제거 (#1)
- [x] T2: 데모 영속 어댑터 (localStorage JSON / IndexedDB Blob)
- [x] T3: resume/role 스토어 hydrate·persist (#2/#4)
- [x] T4: 브라우저 데모 API 클라이언트 디스패치 (uploads 폴스루)
- [x] T5: 공개 토글 시 talents 캐시 무효화 (#3)
- [x] T6: 데모 리셋 경로 (/demo/reset, localStorage + IndexedDB)
- [x] T8: 통합 검증
- [ ] T7: 업로드 IndexedDB + Service Worker → **후속 PR #37로 분리(사용자 승인)**

## 검증 (Stage 1 — Mechanical)
- [x] npm run type-check (clean)
- [x] npm run lint (max-warnings=0, clean)
- [x] npm test (43 files / 182 tests passed)

## Contract Review (Stage 2)
- DoD: pass (#1/#2/#3/#4 + 리셋). 업로드 이미지 영속은 T7으로 이관(#37).
- task 기준: T1~T6 pass, T8 검증 완료, T7 연기.
- seed 기준: acceptance_criteria 중 #1~#4·리셋 pass / 업로드 영속은 후속. constraints 준수(비데모·데이터 shape·서버 라우트·JSON·Blob 분리·시드 1회·단방향 의존), non_goals 미침범.
- 남은 리스크: 업로드 이미지의 서버리스 간헐 미표시(기존 이슈, T7서 해결), localStorage 스키마 버전 변경 시 /demo/reset 필요.

## Adversarial Review (Stage 3)
- 주요 리스크: DEMO_ONLY_MODE에서 모든 브라우저 요청이 로컬 디스패치로 전환 → 데모 전반 영향. 기존 데모/apiClient 테스트 통과로 완화.
- 누락 가능 테스트: 실제 브라우저 IndexedDB(테스트는 in-memory 폴백), localStorage quota 초과 실데이터, SSR 시드 응답 경로.
- 더 단순한 대안: 서버 KV(외부 의존)·쿠키(용량) → 기각.
- 롤백: task 단위 커밋 revert 가능(핵심은 T4 디스패치).
- 판정: pass.

## Drift
Drift score: 0.10
- 테스트 전략 변경(기존 apiClient.test.ts 갱신): +0.10 — 의도된 전송 동작 변경 반영
- 데이터 흐름 변경은 계획된 목표 자체이므로 drift 아님. T7 연기는 승인된 스코프 축소.
판정: 계속.
