### PR TITLE
feat: 데모 업로드 IndexedDB 영속 + Service Worker 서빙 (#37)

### DIFF
--- a/app/(company)/jobs/[jobId]/page.tsx
+++ b/app/(company)/jobs/[jobId]/page.tsx
@@ -5,12 +5,14 @@ import { useRouter } from "next/navigation";
 import BackButton from "@/components/buttons/BackButton";
 import { JobForm } from "@/components/job/JobForm";
 import { useJobPosting, useUpdateJobPosting } from "@/hooks/company/useJobPosting";
+import { useAlert } from "@/contexts/ConfirmContext";
 import type { JobFormData } from "@/types/job";
 import { S3_BASE_URL } from "@/constants/api";
 
 export default function EditJobPage({ params }: { params: Promise<{ jobId: string }> }) {
   const { jobId } = use(params);
   const router = useRouter();
+  const alert = useAlert();
 
   // 기존 데이터 조회
   const { data: jobData, isLoading } = useJobPosting(jobId);
@@ -47,11 +49,14 @@ export default function EditJobPage({ params }: { params: Promise<{ jobId: strin
   const handleSubmit = async (data: JobFormData) => {
     try {
       await updateMutation.mutateAsync(data);
-      alert("채용 공고가 수정되었습니다.");
+      await alert({ title: "채용 공고가 수정되었습니다." });
       router.push("/jobs");
     } catch (error) {
       console.error("Error updating job:", error);
-      alert("채용 공고 수정에 실패했습니다.");
+      await alert({
+        title: "채용 공고 수정에 실패했습니다.",
+        description: "잠시 후 다시 시도해주세요.",
+      });
     }
   };
 

--- a/app/(company)/jobs/_components/JobsLoadingState.tsx
+++ b/app/(company)/jobs/_components/JobsLoadingState.tsx
@@ -1,0 +1,24 @@
+import { JobListHeader } from "./JobListHeader";
+import { JobCardSkeleton } from "./JobCardSkeleton";
+
+/**
+ * 채용공고 관리 첫 페인트용 로딩 상태.
+ * - Suspense fallback과 데이터 로딩(isLoading) 양쪽에서 동일 레이아웃을 재사용한다.
+ * - useSearchParams 등 라우터 훅에 의존하지 않아 Suspense fallback에서 재서스펜드되지 않는다.
+ * - min-h-screen으로 콘텐츠 높이를 예약해 Footer가 먼저 떴다가 밀리는 점프를 막는다(/talents와 동일).
+ */
+export function JobsLoadingState() {
+  return (
+    <div
+      data-testid="jobs-loading"
+      className="container flex flex-col gap-16 w-[1158px] mx-auto p-[72px] min-h-screen"
+    >
+      <JobListHeader />
+      <div className="w-full inline-flex flex-col justify-start items-start gap-16">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <JobCardSkeleton key={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(company)/jobs/_components/__tests__/JobsLoadingState.test.tsx
+++ b/app/(company)/jobs/_components/__tests__/JobsLoadingState.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { JobsLoadingState } from "@/app/(company)/jobs/_components/JobsLoadingState";
+
+describe("JobsLoadingState", () => {
+  it("헤더와 3개의 스켈레톤 카드를 렌더해 첫 페인트부터 콘텐츠 영역을 채운다", () => {
+    const { container } = render(<JobsLoadingState />);
+
+    expect(screen.getByTestId("jobs-loading")).toBeInTheDocument();
+    expect(screen.getByText("채용 공고 관리")).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("콘텐츠 영역 높이를 예약해 Footer 점프를 막는다", () => {
+    render(<JobsLoadingState />);
+
+    expect(screen.getByTestId("jobs-loading")).toHaveClass("min-h-screen");
+  });
+
+  it("라우터 훅에 의존하지 않아 Suspense fallback에서 재서스펜드되지 않는다", () => {
+    // next/navigation 컨텍스트(mock) 없이도 렌더가 성공해야 한다.
+    expect(() => render(<JobsLoadingState />)).not.toThrow();
+  });
+});

--- a/app/(company)/jobs/new/page.tsx
+++ b/app/(company)/jobs/new/page.tsx
@@ -4,20 +4,25 @@ import { useRouter } from "next/navigation";
 import BackButton from "@/components/buttons/BackButton";
 import { JobForm } from "@/components/job/JobForm";
 import { useCreateJobPosting } from "@/hooks/company/useJobPosting";
+import { useAlert } from "@/contexts/ConfirmContext";
 import type { JobFormData } from "@/types/job";
 
 export default function NewJobPage() {
   const router = useRouter();
   const createMutation = useCreateJobPosting();
+  const alert = useAlert();
 
   const handleSubmit = async (data: JobFormData) => {
     try {
       await createMutation.mutateAsync(data);
-      alert("채용 공고가 등록되었습니다.");
+      await alert({ title: "채용 공고가 등록되었습니다." });
       router.push(`/jobs`);
     } catch (error) {
       console.error("Error creating job:", error);
-      alert("채용 공고 등록에 실패했습니다.");
+      await alert({
+        title: "채용 공고 등록에 실패했습니다.",
+        description: "잠시 후 다시 시도해주세요.",
+      });
     }
   };
 

--- a/app/(company)/jobs/page.tsx
+++ b/app/(company)/jobs/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { JobListHeader } from "./_components/JobListHeader";
 import { JobCardContainer } from "./_components/JobCardContainer";
-import { JobCardSkeleton } from "./_components/JobCardSkeleton";
+import { JobsLoadingState } from "./_components/JobsLoadingState";
 import { useJobPostings } from "@/hooks/company/useJobPosting";
 import Pager from "@/components/Pager";
 
@@ -25,16 +25,7 @@ function JobsContent() {
 
   // 로딩 중이거나 데이터가 아직 없는 경우 스켈레톤 표시
   if (isLoading || !data) {
-    return (
-      <div className="container flex flex-col gap-16 w-[1158px] mx-auto p-[72px]">
-        <JobListHeader />
-        <div className="w-full inline-flex flex-col justify-start items-start gap-16">
-          {Array.from({ length: 3 }).map((_, index) => (
-            <JobCardSkeleton key={index} />
-          ))}
-        </div>
-      </div>
-    );
+    return <JobsLoadingState />;
   }
 
   if (isError) {
@@ -87,7 +78,7 @@ function JobsContent() {
 
 export default function JobsPage() {
   return (
-    <Suspense fallback={<div className="container w-[1158px] mx-auto mb-[191px]" />}>
+    <Suspense fallback={<JobsLoadingState />}>
       <JobsContent />
     </Suspense>
   );

--- a/app/(company)/talents/[talentId]/_components/IntroduceCard.tsx
+++ b/app/(company)/talents/[talentId]/_components/IntroduceCard.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Badge from "@/components/ui/badge";
 import type { BadgeType } from "@/components/ui/badge";
 import SkillChips from "@/components/chips/SkillChips";
+import { isClientServedImage } from "@/utils/imageSrc";
 
 type BadgeItem = { label: string; type: BadgeType };
 
@@ -122,7 +123,14 @@ export default function IntroduceCard(props: IntroduceCardProps) {
         {/* 왼쪽: 프로필 */}
         <div className="w-40 inline-flex flex-col justify-start items-start gap-8">
           <div className="w-40 h-48 relative rounded-lg overflow-hidden bg-[#F5F5F5] border border-border-quaternary">
-            <Image src={src} alt={`${name} 프로필 이미지`} fill className="object-cover" priority />
+            <Image
+              src={src}
+              alt={`${name} 프로필 이미지`}
+              fill
+              className="object-cover"
+              priority
+              unoptimized={isClientServedImage(src)}
+            />
           </div>
           {/* 리스팅 페이지에서만 상세보기 버튼 표시 */}
           {showDetailButton && href && (

--- a/app/dashboard/job-board/_components/JobCard.tsx
+++ b/app/dashboard/job-board/_components/JobCard.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { cn } from "@/utils/utils";
+import { isClientServedImage } from "@/utils/imageSrc";
 
 interface JobCardProps extends React.HTMLAttributes<HTMLDivElement> {
   jobPostingId: number;
@@ -49,6 +50,7 @@ export function JobCard({
           className="object-cover scale-110 blur-xl opacity-45"
           sizes="275px"
           priority={false}
+          unoptimized={isClientServedImage(imageUrl)}
         />
         <Image
           src={imageUrl}
@@ -57,6 +59,7 @@ export function JobCard({
           className="object-contain relative z-10"
           sizes="275px"
           priority={false}
+          unoptimized={isClientServedImage(imageUrl)}
         />
         <div className="w-6 h-6 left-[222px] top-[10px] absolute z-20" />
       </div>

--- a/app/dashboard/job-board/_components/JobImageCarousel.tsx
+++ b/app/dashboard/job-board/_components/JobImageCarousel.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useState } from "react";
+import { isClientServedImage } from "@/utils/imageSrc";
 
 interface JobImageCarouselProps {
   images: string[];
@@ -53,6 +54,7 @@ export default function JobImageCarousel({ images }: JobImageCarouselProps) {
               aria-hidden="true"
               className="object-cover scale-110 blur-xl opacity-45"
               sizes="570px"
+              unoptimized={isClientServedImage(image)}
             />
             <Image
               src={image}
@@ -60,6 +62,7 @@ export default function JobImageCarousel({ images }: JobImageCarouselProps) {
               fill
               className="object-contain relative z-10"
               sizes="570px"
+              unoptimized={isClientServedImage(image)}
             />
           </div>
         ))}

--- a/app/dashboard/profile/[profileId]/_components/sections/ProfileImageSection.tsx
+++ b/app/dashboard/profile/[profileId]/_components/sections/ProfileImageSection.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import type { TalentRegisterFormValues } from "@/schemas/talent/talentRegisterSchema";
 import AddButton from "../AddButton";
 import { useTalentRegisterStore } from "@/store/talentRegisterStore";
+import { isClientServedImage } from "@/utils/imageSrc";
 
 export default function ProfileImageSection() {
   const {
@@ -116,6 +117,7 @@ export default function ProfileImageSection() {
             fill
             className="object-cover"
             sizes="(max-width: 768px) 128px, 160px"
+            unoptimized={isClientServedImage(previewUrl)}
           />
         </button>
 

--- a/app/demo/_components/DemoResetButton.tsx
+++ b/app/demo/_components/DemoResetButton.tsx
@@ -2,12 +2,9 @@
 
 import { useState } from "react";
 import { clearDemoAuthState } from "@/lib/demoAuthClient";
+import { resetAllDemoData } from "@/lib/demo/reset";
 
-const DEMO_LOCAL_STORAGE_KEYS = [
-  "auth-store",
-  "lion-connect-demo-api-log",
-  "lion-connect-demo-resume-store",
-];
+const DEMO_LOCAL_STORAGE_KEYS = ["auth-store", "lion-connect-demo-api-log"];
 
 const DEMO_SESSION_STORAGE_KEYS = ["lion-connect-demo-guide-seen"];
 
@@ -19,6 +16,8 @@ export default function DemoResetButton() {
 
     try {
       await clearDemoAuthState();
+      // 이력서/역할 스토어(demo: JSON) + 업로드 바이너리(IndexedDB) 초기화 + 인메모리 재시드.
+      await resetAllDemoData();
       DEMO_LOCAL_STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
       DEMO_SESSION_STORAGE_KEYS.forEach((key) => window.sessionStorage.removeItem(key));
       setStatus("done");
@@ -39,10 +38,10 @@ export default function DemoResetButton() {
       </button>
       <p className="text-xs leading-5 text-neutral-500" aria-live="polite">
         {status === "done"
-          ? "브라우저에 남은 데모 인증과 로컬 데모 데이터를 정리했습니다."
+          ? "데모 인증과 이력서·업로드 파일을 모두 초기 상태로 되돌렸습니다."
           : status === "error"
             ? "초기화에 실패했습니다. 새로고침 후 다시 시도해주세요."
-            : "브라우저 localStorage/sessionStorage와 데모 인증 쿠키만 정리합니다."}
+            : "데모 인증, 이력서/역할 데이터, 업로드 파일을 모두 처음 상태로 되돌립니다."}
       </p>
     </div>
   );

--- a/app/demo/_components/DemoResetButton.tsx
+++ b/app/demo/_components/DemoResetButton.tsx
@@ -9,7 +9,7 @@ const DEMO_LOCAL_STORAGE_KEYS = ["auth-store", "lion-connect-demo-api-log"];
 const DEMO_SESSION_STORAGE_KEYS = ["lion-connect-demo-guide-seen"];
 
 export default function DemoResetButton() {
-  const [status, setStatus] = useState<"idle" | "clearing" | "done" | "error">("idle");
+  const [status, setStatus] = useState<"idle" | "clearing" | "error">("idle");
 
   const handleReset = async () => {
     setStatus("clearing");
@@ -20,7 +20,8 @@ export default function DemoResetButton() {
       await resetAllDemoData();
       DEMO_LOCAL_STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
       DEMO_SESSION_STORAGE_KEYS.forEach((key) => window.sessionStorage.removeItem(key));
-      setStatus("done");
+      // 초기화 직후 전체 새로고침으로 인메모리 스토어와 React Query 캐시까지 시드 상태로 재생성한다.
+      window.location.reload();
     } catch {
       setStatus("error");
     }
@@ -37,11 +38,9 @@ export default function DemoResetButton() {
         {status === "clearing" ? "초기화 중..." : "데모 데이터 초기화"}
       </button>
       <p className="text-xs leading-5 text-neutral-500" aria-live="polite">
-        {status === "done"
-          ? "데모 인증과 이력서·업로드 파일을 모두 초기 상태로 되돌렸습니다."
-          : status === "error"
-            ? "초기화에 실패했습니다. 새로고침 후 다시 시도해주세요."
-            : "데모 인증, 이력서/역할 데이터, 업로드 파일을 모두 처음 상태로 되돌립니다."}
+        {status === "error"
+          ? "초기화에 실패했습니다. 새로고침 후 다시 시도해주세요."
+          : "데모 인증, 이력서/역할 데이터, 업로드 파일을 모두 처음 상태로 되돌린 뒤 새로고침합니다."}
       </p>
     </div>
   );

--- a/app/demo/_components/__tests__/DemoResetButton.test.tsx
+++ b/app/demo/_components/__tests__/DemoResetButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const clearDemoAuthState = vi.fn();
+const resetAllDemoData = vi.fn();
+
+vi.mock("@/lib/demoAuthClient", () => ({
+  clearDemoAuthState: () => clearDemoAuthState(),
+}));
+
+vi.mock("@/lib/demo/reset", () => ({
+  resetAllDemoData: () => resetAllDemoData(),
+}));
+
+import DemoResetButton from "@/app/demo/_components/DemoResetButton";
+
+describe("DemoResetButton", () => {
+  beforeEach(() => {
+    clearDemoAuthState.mockResolvedValue(undefined);
+    resetAllDemoData.mockResolvedValue(undefined);
+    window.localStorage.setItem("auth-store", "x");
+    window.localStorage.setItem("lion-connect-demo-api-log", "x");
+    window.sessionStorage.setItem("lion-connect-demo-guide-seen", "x");
+  });
+
+  it("이력서/업로드까지 포함해 데모 데이터를 완전 초기화한다", async () => {
+    const user = userEvent.setup();
+    render(<DemoResetButton />);
+
+    await user.click(screen.getByRole("button", { name: "데모 데이터 초기화" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("데모 인증과 이력서·업로드 파일을 모두 초기 상태로 되돌렸습니다.")
+      ).toBeInTheDocument();
+    });
+
+    // auth 정리 + 이력서/역할/IndexedDB 초기화(resetAllDemoData) 모두 호출
+    expect(clearDemoAuthState).toHaveBeenCalledTimes(1);
+    expect(resetAllDemoData).toHaveBeenCalledTimes(1);
+
+    // 남은 localStorage/sessionStorage 키 정리
+    expect(window.localStorage.getItem("auth-store")).toBeNull();
+    expect(window.localStorage.getItem("lion-connect-demo-api-log")).toBeNull();
+    expect(window.sessionStorage.getItem("lion-connect-demo-guide-seen")).toBeNull();
+  });
+
+  it("초기화 실패 시 에러 메시지를 보여준다", async () => {
+    resetAllDemoData.mockRejectedValueOnce(new Error("boom"));
+    const user = userEvent.setup();
+    render(<DemoResetButton />);
+
+    await user.click(screen.getByRole("button", { name: "데모 데이터 초기화" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("초기화에 실패했습니다. 새로고침 후 다시 시도해주세요.")
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/app/demo/_components/__tests__/DemoResetButton.test.tsx
+++ b/app/demo/_components/__tests__/DemoResetButton.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const clearDemoAuthState = vi.fn();
 const resetAllDemoData = vi.fn();
@@ -16,31 +16,44 @@ vi.mock("@/lib/demo/reset", () => ({
 import DemoResetButton from "@/app/demo/_components/DemoResetButton";
 
 describe("DemoResetButton", () => {
+  const originalLocation = window.location;
+  let reloadMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     clearDemoAuthState.mockResolvedValue(undefined);
     resetAllDemoData.mockResolvedValue(undefined);
+    reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
     window.localStorage.setItem("auth-store", "x");
     window.localStorage.setItem("lion-connect-demo-api-log", "x");
     window.sessionStorage.setItem("lion-connect-demo-guide-seen", "x");
   });
 
-  it("이력서/업로드까지 포함해 데모 데이터를 완전 초기화한다", async () => {
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("이력서/업로드까지 포함해 완전 초기화한 뒤 전체 새로고침한다", async () => {
     const user = userEvent.setup();
     render(<DemoResetButton />);
 
     await user.click(screen.getByRole("button", { name: "데모 데이터 초기화" }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("데모 인증과 이력서·업로드 파일을 모두 초기 상태로 되돌렸습니다.")
-      ).toBeInTheDocument();
+      expect(reloadMock).toHaveBeenCalledTimes(1);
     });
 
     // auth 정리 + 이력서/역할/IndexedDB 초기화(resetAllDemoData) 모두 호출
     expect(clearDemoAuthState).toHaveBeenCalledTimes(1);
     expect(resetAllDemoData).toHaveBeenCalledTimes(1);
 
-    // 남은 localStorage/sessionStorage 키 정리
+    // 남은 localStorage/sessionStorage 키는 새로고침 전에 정리된다.
     expect(window.localStorage.getItem("auth-store")).toBeNull();
     expect(window.localStorage.getItem("lion-connect-demo-api-log")).toBeNull();
     expect(window.sessionStorage.getItem("lion-connect-demo-guide-seen")).toBeNull();

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,6 +7,7 @@ import SuccessToast from "@/components/SuccessToast";
 import { ConfirmProvider } from "@/contexts/ConfirmContext";
 import { DemoGuideProvider } from "@/contexts/DemoGuideContext";
 import DemoApiLogPanel from "@/components/demo/DemoApiLogPanel";
+import DemoServiceWorkerRegistrar from "@/components/demo/DemoServiceWorkerRegistrar";
 import { ReactNode } from "react";
 
 /**
@@ -42,6 +43,7 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <InitializeApp />
+      <DemoServiceWorkerRegistrar />
       <SuccessToast />
       <ConfirmProvider>
         <DemoGuideProvider>{children}</DemoGuideProvider>

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -11,6 +11,10 @@ interface ConfirmModalProps {
   cancelLabel: string;
   onClose: () => void;
   onConfirm: () => void;
+  /** 취소 버튼 숨김 (성공/안내용 단일 확인 모달) */
+  hideCancel?: boolean;
+  /** 확인 버튼 색상. 기본 danger(빨강), primary(브랜드) 선택 가능 */
+  tone?: "danger" | "primary";
 }
 
 export function ConfirmModal({
@@ -21,6 +25,8 @@ export function ConfirmModal({
   cancelLabel,
   onClose,
   onConfirm,
+  hideCancel = false,
+  tone = "danger",
 }: ConfirmModalProps) {
   useEffect(() => {
     if (!open) return;
@@ -44,10 +50,7 @@ export function ConfirmModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      role="presentation"
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="presentation">
       <div
         className="absolute inset-0 bg-black/50 transition-opacity duration-200"
         onClick={handleBackdropClick}
@@ -66,9 +69,7 @@ export function ConfirmModal({
       >
         <div className="self-stretch py-5 flex flex-col justify-center items-start gap-2.5">
           <div className="px-5 flex justify-start items-center gap-2.5">
-            <h2 className="text-black text-xl font-bold font-['Pretendard'] leading-7">
-              {title}
-            </h2>
+            <h2 className="text-black text-xl font-bold font-['Pretendard'] leading-7">{title}</h2>
           </div>
           {description && (
             <div className="self-stretch px-5 flex justify-start items-center gap-2.5">
@@ -80,32 +81,39 @@ export function ConfirmModal({
         </div>
 
         <div className="self-stretch  px-5 pb-5 flex justify-end items-center gap-3">
-          <button
-            data-color="default"
-            data-state="default"
-            data-type="cancel"
-            onClick={onClose}
-            className={cn(
-              "px-2 py-1 rounded flex cursor-pointer justify-center items-center gap-2.5",
-              "hover:bg-neutral-100 transition-colors"
-            )}
-          >
-            <span className="text-neutral-500 text-sm font-semibold font-['Pretendard'] leading-5">
-              {cancelLabel}
-            </span>
-          </button>
+          {!hideCancel && (
+            <button
+              data-color="default"
+              data-state="default"
+              data-type="cancel"
+              onClick={onClose}
+              className={cn(
+                "px-2 py-1 rounded flex cursor-pointer justify-center items-center gap-2.5",
+                "hover:bg-neutral-100 transition-colors"
+              )}
+            >
+              <span className="text-neutral-500 text-sm font-semibold font-['Pretendard'] leading-5">
+                {cancelLabel}
+              </span>
+            </button>
+          )}
 
           <button
-            data-color="red"
+            data-color={tone === "primary" ? "primary" : "red"}
             data-state="default"
             data-type="check"
             onClick={onConfirm}
             className={cn(
-              "px-2 py-1 rounded cursor-pointer flex justify-center items-center",
-              "hover:bg-red-50 transition-colors"
+              "px-2 py-1 rounded cursor-pointer flex justify-center items-center transition-colors",
+              tone === "primary" ? "hover:bg-orange-50" : "hover:bg-red-50"
             )}
           >
-            <span className="text-red-500 text-sm font-semibold font-['Pretendard'] leading-5">
+            <span
+              className={cn(
+                "text-sm font-semibold font-['Pretendard'] leading-5",
+                tone === "primary" ? "text-orange-600" : "text-red-500"
+              )}
+            >
               {confirmLabel}
             </span>
           </button>

--- a/components/demo/DemoServiceWorkerRegistrar.tsx
+++ b/components/demo/DemoServiceWorkerRegistrar.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { registerDemoServiceWorker } from "@/lib/demo/registerDemoServiceWorker";
+
+/**
+ * 데모 모드에서 업로드 영속 Service Worker를 마운트 시 1회 등록한다.
+ * 미지원/비데모 환경에서는 등록 유틸이 no-op이므로 항상 안전하게 렌더 가능.
+ */
+export default function DemoServiceWorkerRegistrar() {
+  useEffect(() => {
+    void registerDemoServiceWorker();
+  }, []);
+
+  return null;
+}

--- a/components/form/ImageUpload.tsx
+++ b/components/form/ImageUpload.tsx
@@ -12,6 +12,7 @@
 import { useRef, useState } from "react";
 import Image from "next/image";
 import { cn } from "@/utils/utils";
+import { isClientServedImage } from "@/utils/imageSrc";
 
 import type { JobImageMetadata } from "@/types/job";
 
@@ -59,7 +60,7 @@ export function ImageUpload({
   existingImageMetadata = [],
   onExistingImagesChange,
   maxImages = 5,
-  error
+  error,
 }: ImageUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   // 초기 미리보기 URL은 기존 이미지 URL들로 설정
@@ -78,7 +79,7 @@ export function ImageUpload({
     const totalFiles = [...value, ...filesToAdd];
 
     // 새로 추가된 파일들의 미리보기 URL만 생성
-    const newFileUrls = filesToAdd.map(file => URL.createObjectURL(file));
+    const newFileUrls = filesToAdd.map((file) => URL.createObjectURL(file));
     setPreviewUrls([...previewUrls, ...newFileUrls]);
 
     onChange?.(totalFiles);
@@ -124,6 +125,7 @@ export function ImageUpload({
             alt={`Preview ${index + 1}`}
             fill
             sizes="288px"
+            unoptimized={isClientServedImage(url)}
           />
           <button
             type="button"

--- a/contexts/ConfirmContext.tsx
+++ b/contexts/ConfirmContext.tsx
@@ -8,7 +8,13 @@ export type ConfirmOptions = {
   description?: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  /** 취소 버튼 숨김 (성공/안내용 단일 확인 모달) */
+  hideCancel?: boolean;
+  /** 확인 버튼 색상. 기본 danger(빨강), primary(브랜드) 선택 가능 */
+  tone?: "danger" | "primary";
 };
+
+export type AlertOptions = Omit<ConfirmOptions, "cancelLabel" | "hideCancel">;
 
 type InternalConfirmState = ConfirmOptions & {
   isOpen: boolean;
@@ -17,6 +23,8 @@ type InternalConfirmState = ConfirmOptions & {
 
 type ConfirmContextValue = {
   confirm: (options: ConfirmOptions) => Promise<boolean>;
+  /** 단일 확인 버튼 안내 모달. 닫히면 resolve된다(성공 알림 등). */
+  alert: (options: AlertOptions) => Promise<void>;
 };
 
 const ConfirmContext = createContext<ConfirmContextValue | null>(null);
@@ -34,6 +42,17 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const alert = useCallback(
+    (options: AlertOptions) =>
+      confirm({
+        confirmLabel: "확인",
+        tone: "primary",
+        ...options,
+        hideCancel: true,
+      }).then(() => undefined),
+    [confirm]
+  );
+
   const handleResolve = (value: boolean) => {
     setState((prev) => {
       if (prev?.resolve) {
@@ -44,7 +63,7 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <ConfirmContext.Provider value={{ confirm }}>
+    <ConfirmContext.Provider value={{ confirm, alert }}>
       {children}
       {/* Global Confirm Modal Host */}
       {state?.isOpen && (
@@ -54,6 +73,8 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
           description={state.description}
           confirmLabel={state.confirmLabel || "확인"}
           cancelLabel={state.cancelLabel || "취소"}
+          hideCancel={state.hideCancel}
+          tone={state.tone}
           onClose={() => handleResolve(false)}
           onConfirm={() => handleResolve(true)}
         />
@@ -68,4 +89,12 @@ export function useConfirm() {
     throw new Error("useConfirm must be used within ConfirmProvider");
   }
   return ctx.confirm;
+}
+
+export function useAlert() {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error("useAlert must be used within ConfirmProvider");
+  }
+  return ctx.alert;
 }

--- a/contexts/__tests__/ConfirmContext.test.tsx
+++ b/contexts/__tests__/ConfirmContext.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { ConfirmProvider, useAlert, useConfirm } from "@/contexts/ConfirmContext";
+
+function AlertHarness() {
+  const alert = useAlert();
+  const [done, setDone] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={async () => {
+          await alert({ title: "채용 공고가 수정되었습니다." });
+          setDone(true);
+        }}
+      >
+        저장
+      </button>
+      {done && <p>리스트 이동</p>}
+    </div>
+  );
+}
+
+function ConfirmHarness() {
+  const confirm = useConfirm();
+  const [result, setResult] = useState<string>("");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={async () => {
+          const ok = await confirm({ title: "삭제하시겠습니까?" });
+          setResult(ok ? "확인됨" : "취소됨");
+        }}
+      >
+        삭제
+      </button>
+      {result && <p>{result}</p>}
+    </div>
+  );
+}
+
+describe("ConfirmContext alert/confirm", () => {
+  it("alert는 취소 없이 단일 확인 모달을 띄우고, 확인하면 후속 동작(리스트 이동)이 이어진다", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmProvider>
+        <AlertHarness />
+      </ConfirmProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(await screen.findByText("채용 공고가 수정되었습니다.")).toBeInTheDocument();
+    // 안내 모달은 취소 버튼이 없다.
+    expect(screen.queryByText("취소")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "확인" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("리스트 이동")).toBeInTheDocument();
+    });
+  });
+
+  it("confirm은 기존대로 취소/확인 두 버튼을 유지한다", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmProvider>
+        <ConfirmHarness />
+      </ConfirmProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "삭제" }));
+
+    expect(await screen.findByText("삭제하시겠습니까?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "취소" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "확인" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("확인됨")).toBeInTheDocument();
+    });
+  });
+});

--- a/docs/demo-uploads-service-worker.md
+++ b/docs/demo-uploads-service-worker.md
@@ -1,0 +1,82 @@
+# 데모 업로드 영속화 — Service Worker + IndexedDB (이슈 #37)
+
+데모 모드에서 사용자가 올린 이미지/포트폴리오가 **새로고침 후에도 유지**되도록 한 설계와,
+구현 중 내린 결정·주의사항을 기록한다. (PR #38)
+
+## 배경 (근본 원인)
+
+- 배포는 Vercel(서버리스, 다중 인스턴스). 인메모리 데모 스토어는 인스턴스 간 공유되지 않는다.
+- PR #36에서 데모 **JSON 상태**를 브라우저 단일 소스(localStorage)로 옮겼지만, **업로드 바이너리**는
+  여전히 서버 라우트(인메모리)에 저장돼 새로고침/인스턴스 전환 시 사라졌다.
+- 따라서 업로드 바이너리도 브라우저(IndexedDB)로 옮겨 단일 소스를 완성한다.
+
+## 아키텍처
+
+```
+업로드 PUT  /api/demo/uploads/{objectKey}   ─┐
+이미지 GET  /api/demo/uploads/{objectKey}   ─┤→ [Service Worker] ⇄ IndexedDB(demo-uploads/blobs)
+                                              └→ (SW 미등록/IDB 미스 시) 서버 라우트 폴백
+```
+
+- **`public/demo-sw.js`** (무의존 plain JS): `/api/demo/uploads/*` 만 `fetch` 가로채기
+  - `PUT`/`POST`: 요청 body(Blob)를 IndexedDB에 저장 → `204`
+  - `GET`: IndexedDB에서 서빙, 없으면 `fetch(request)`로 서버 라우트 폴백
+  - 그 외 경로/메서드는 **respondWith 호출 안 함** → 기본 네트워크 동작(절대 안 건드림)
+- **등록**: `lib/demo/registerDemoServiceWorker.ts` → `components/demo/DemoServiceWorkerRegistrar.tsx`
+  (`app/providers.tsx`에 마운트). 데모 모드 + `serviceWorker` 지원 시에만 등록, 실패는 폴백으로 흡수.
+- **무변경**: `apiClient`의 uploads 폴스루, `uploadThumbnailToS3`의 raw `fetch`, `<img>` 네이티브 요청.
+  SW가 네트워크 레벨에서 투명하게 가로채므로 호출 코드를 바꿀 필요가 없다.
+
+### IndexedDB 스키마는 반드시 한 곳과 일치
+
+`public/demo-sw.js`와 `lib/demo/persistence.ts`는 **동일** 스키마를 써야 한다.
+
+| 항목 | 값 |
+| --- | --- |
+| DB 이름 | `demo-uploads` |
+| 버전 | `1` |
+| objectStore | `blobs` |
+| 키 | `objectKey` (`/api/demo/uploads/` 뒤 경로) |
+
+그래야 `/demo/reset`의 `clearDemoBlobs()`가 **SW가 쓴 blob까지** 같은 스토어에서 비운다.
+SW는 무의존이라 상수를 import 할 수 없으므로, `__tests__/uploadSchemaSync.test.ts`가
+SW 파일 텍스트와 `persistence.ts` 상수의 일치를 **고정**한다.
+
+## next/image 함정 (이미지가 alt로 깨져 보이던 원인)
+
+`next/image`는 기본적으로 `/_next/image?url=...` 경유로 **서버 사이드에서** src를 fetch해 최적화한다.
+그런데 데모 업로드 blob은 **브라우저 IndexedDB에만** 존재한다. 서버 옵티마이저가
+`/api/demo/uploads/...`를 서버에서 가져오면 빈 인메모리 라우트로 가 404 → **깨진 이미지(alt 노출)**.
+`blob:`/`data:` objectURL(파일 선택 직후 미리보기)도 서버가 가져올 수 없어 동일하게 깨진다.
+
+**해결**: 클라이언트에서만 서빙되는 src는 `unoptimized`로 렌더해 `/_next/image` 프록시를 우회하고
+브라우저가 직접 요청하게 한다(→ SW가 IndexedDB에서 서빙).
+
+- 판정 헬퍼: `utils/imageSrc.ts`의 `isClientServedImage(src)`
+  (`blob:` / `data:` / `/api/demo/uploads/` → `true`. 정적 에셋·외부 https에는 무영향.)
+- 적용: `ProfileImageSection`, `IntroduceCard`, `JobImageCarousel`, `JobCard`(job-board), `ImageUpload`
+- `PortfolioCard`는 `<iframe>`/`<object>`로 직접 요청 → SW가 가로채므로 추가 변경 불필요.
+
+## SW 런타임 검증 전략 (e2e 대신 단위 + 수동/배포)
+
+**결정: Playwright e2e를 추가하지 않고, 등록 유틸 테스트 + 스키마 동기화 테스트 + 수동/배포 검증으로 커버한다.**
+
+- 이유:
+  - SW 런타임(install/activate/fetch 가로채기)은 **jsdom에서 단위 테스트가 불가능**하다.
+  - Playwright로 SW를 검증하려면 실제 dev 서버 + 복잡한 썸네일 업로드 UI 흐름을 구동해야 해 **ROI가 낮다**.
+  - 회귀 방지의 핵심(스키마 불일치 시 reset 누락)은 이미 **스키마 동기화 테스트**가 고정한다.
+- 자동 검증:
+  - `registerDemoServiceWorker.test.ts`: 데모+지원 시 등록 / 미지원·비데모 no-op / 등록 실패 흡수
+  - `uploadSchemaSync.test.ts`: SW ↔ `persistence.ts` 스키마 일치 고정
+  - `imageSrc.test.ts`: `unoptimized` 판정
+- 수동/배포 검증 체크리스트:
+  1. 썸네일 업로드 → 새로고침 → 이미지 200 유지(깨지지 않음)
+  2. 포트폴리오(PDF) 업로드 → 새로고침 → 미리보기 유지
+  3. `/demo/reset` 후 업로드 이미지가 기본 상태로 복원
+  4. SW 미지원/실패 시 서버 라우트 폴백으로 graceful degrade(앱 안 깨짐)
+
+## 주의사항
+
+- SW는 한 번 등록되면 끈질기게 남는다. **최소·무캐시**로 작성하고 `/api/demo/uploads/*` 외 요청은 절대 건드리지 않는다.
+- 캐시버스터 쿼리(`?v=...`)는 SW가 `pathname`만 보고 objectKey를 뽑으므로 영향 없다.
+- 스키마(DB명/버전/스토어명)를 바꿀 때는 `public/demo-sw.js`와 `lib/demo/persistence.ts`를 **함께** 바꿔야 한다(테스트가 막아준다).

--- a/lib/demo/__tests__/registerDemoServiceWorker.test.ts
+++ b/lib/demo/__tests__/registerDemoServiceWorker.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const isDemoOnlyMode = vi.fn();
+vi.mock("@/lib/demoMode", () => ({
+  isDemoOnlyMode: () => isDemoOnlyMode(),
+}));
+
+import { registerDemoServiceWorker } from "@/lib/demo/registerDemoServiceWorker";
+
+function setServiceWorker(value: unknown) {
+  Object.defineProperty(navigator, "serviceWorker", {
+    value,
+    configurable: true,
+  });
+}
+
+function clearServiceWorker() {
+  if ("serviceWorker" in navigator) {
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+  }
+}
+
+describe("registerDemoServiceWorker", () => {
+  beforeEach(() => {
+    isDemoOnlyMode.mockReturnValue(true);
+    clearServiceWorker();
+  });
+
+  afterEach(() => {
+    clearServiceWorker();
+    vi.restoreAllMocks();
+  });
+
+  it("데모 모드 + serviceWorker 지원 시 /demo-sw.js 를 scope / 로 등록한다", async () => {
+    const register = vi.fn().mockResolvedValue({ scope: "/" });
+    setServiceWorker({ register });
+
+    const result = await registerDemoServiceWorker();
+
+    expect(register).toHaveBeenCalledWith("/demo-sw.js", { scope: "/" });
+    expect(result).toEqual({ scope: "/" });
+  });
+
+  it("serviceWorker 미지원이면 no-op 으로 null 을 반환한다", async () => {
+    const result = await registerDemoServiceWorker();
+    expect(result).toBeNull();
+  });
+
+  it("비데모 모드면 등록을 시도하지 않는다", async () => {
+    isDemoOnlyMode.mockReturnValue(false);
+    const register = vi.fn();
+    setServiceWorker({ register });
+
+    const result = await registerDemoServiceWorker();
+
+    expect(register).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("등록 실패는 null 로 흡수한다(서버 라우트 폴백)", async () => {
+    const register = vi.fn().mockRejectedValue(new Error("register failed"));
+    setServiceWorker({ register });
+
+    const result = await registerDemoServiceWorker();
+
+    expect(register).toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/lib/demo/__tests__/roleMockApi.test.ts
+++ b/lib/demo/__tests__/roleMockApi.test.ts
@@ -96,6 +96,37 @@ describe("demo role page mock API", () => {
     expect(canceled.status).toBe(204);
   });
 
+  it("시드 공고의 제목만 수정해도 정적 커버 이미지 URL이 유지된다(깨지지 않음)", async () => {
+    // 실제 수정 요청은 백엔드 계약상 기존 이미지의 url/fileUrl을 제거하고 objectKey만 보낸다.
+    const updateBody = {
+      ...jobPostingRequest,
+      title: "제목만 바꾼 데모 공고",
+      images: [
+        {
+          objectKey: "demo/demo-cover.png",
+          contentType: "image/png",
+          fileSize: 1024,
+          originalFilename: "demo-cover.png",
+          sortOrder: 1,
+        },
+      ],
+    };
+
+    const updated = await callDemoApi("PUT", "/company/job-postings/9001", updateBody);
+    const detail = await callDemoApi("GET", "/company/job-postings/9001");
+
+    expect(updated.status).toBe(200);
+    expect(detail.body.title).toBe("제목만 바꾼 데모 공고");
+    // /api/demo/uploads/... 로 재구성되지 않고 정적 경로를 유지해야 한다.
+    expect(detail.body.images[0]).toEqual(
+      expect.objectContaining({
+        objectKey: "demo/demo-cover.png",
+        url: "/demo/demo-cover.png",
+        fileUrl: "/demo/demo-cover.png",
+      })
+    );
+  });
+
   it("지원 상태는 채용공고 상세와 지원 현황 목록에 함께 반영된다", async () => {
     const initialDetail = await callDemoApi("GET", "/job-postings/9001");
     const initialApplications = await callDemoApi("GET", "/me/job-applications?page=0&size=10");

--- a/lib/demo/__tests__/uploadSchemaSync.test.ts
+++ b/lib/demo/__tests__/uploadSchemaSync.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { DB_NAME, DB_VERSION, STORE_NAME } from "@/lib/demo/persistence";
+
+/**
+ * Service Worker(`public/demo-sw.js`)와 영속 어댑터(`lib/demo/persistence.ts`)는
+ * 동일한 IndexedDB 스키마를 써야 한다. 그래야 `clearDemoBlobs()`가 SW가 쓴 blob을
+ * 같은 스토어에서 비울 수 있다. SW는 무의존 plain JS라 상수를 import 할 수 없으므로
+ * 파일 텍스트로 일관성을 고정한다.
+ */
+describe("데모 업로드 IndexedDB 스키마 동기화", () => {
+  const swSource = readFileSync(path.resolve(__dirname, "../../../public/demo-sw.js"), "utf-8");
+
+  it("SW가 persistence 와 동일한 DB명/스토어명을 사용한다", () => {
+    expect(swSource).toContain(`"${DB_NAME}"`);
+    expect(swSource).toContain(`"${STORE_NAME}"`);
+  });
+
+  it("SW가 persistence 와 동일한 DB 버전을 사용한다", () => {
+    expect(swSource).toMatch(new RegExp(`DB_VERSION\\s*=\\s*${DB_VERSION}\\b`));
+  });
+
+  it("SW는 /api/demo/uploads/ 경로만 가로챈다", () => {
+    expect(swSource).toContain("/api/demo/uploads/");
+  });
+});

--- a/lib/demo/persistence.ts
+++ b/lib/demo/persistence.ts
@@ -53,9 +53,15 @@ export function removeDemoJson(key: string): void {
  * Blob 저장 (IndexedDB / in-memory 폴백)
  * ================================ */
 
-const DB_NAME = "demo-uploads";
-const DB_VERSION = 1;
-const STORE_NAME = "blobs";
+/**
+ * IndexedDB 스키마 상수.
+ * `public/demo-sw.js`(Service Worker)도 동일한 DB명/버전/스토어명을 사용해야 한다.
+ * (SW가 쓴 blob을 여기 `clearDemoBlobs()`가 같은 스토어에서 비울 수 있도록 일치 유지.)
+ * 일관성은 `__tests__/uploadSchemaSync.test.ts`가 고정한다.
+ */
+export const DB_NAME = "demo-uploads";
+export const DB_VERSION = 1;
+export const STORE_NAME = "blobs";
 
 /** IndexedDB 미가용 환경(SSR/jsdom 등)에서 사용하는 폴백. */
 let memoryBlobs: Map<string, Blob> | null = null;

--- a/lib/demo/registerDemoServiceWorker.ts
+++ b/lib/demo/registerDemoServiceWorker.ts
@@ -1,0 +1,19 @@
+import { isDemoOnlyMode } from "@/lib/demoMode";
+
+const DEMO_SW_URL = "/demo-sw.js";
+
+/**
+ * 데모 업로드(`/api/demo/uploads/*`)를 IndexedDB로 영속·서빙하는 Service Worker를 등록한다.
+ *
+ * - 데모 모드가 아니거나 `serviceWorker` 미지원 환경이면 아무것도 하지 않고 `null`을 반환한다.
+ * - 등록이 실패해도 서버 라우트 폴백으로 graceful degrade되므로 조용히 `null`로 흡수한다.
+ * - SW는 `/api/demo/uploads/*` 외 요청은 절대 건드리지 않으므로 scope `/` 로 등록해도 안전하다.
+ */
+export function registerDemoServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!isDemoOnlyMode()) return Promise.resolve(null);
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return Promise.resolve(null);
+  }
+
+  return navigator.serviceWorker.register(DEMO_SW_URL, { scope: "/" }).catch(() => null);
+}

--- a/lib/demo/roleStore.ts
+++ b/lib/demo/roleStore.ts
@@ -172,8 +172,28 @@ function toSupportedEmploymentType(
   return employmentType === "CONTRACT" ? "INTERN" : employmentType;
 }
 
+/**
+ * 정적 시드 커버 이미지(objectKey → `/demo/*.png`).
+ * 시드 이미지는 IndexedDB 업로드 blob이 아니라 `public/demo/` 정적 파일이다.
+ * 수정 요청은 백엔드 계약상 `url`/`fileUrl`을 제거하고 objectKey만 보내므로(lib/api/jobPostings.ts),
+ * 이 매핑이 없으면 수정 라운드트립 후 `/api/demo/uploads/{objectKey}`로 바뀌어 깨진다(blob 부재 → 404).
+ * 시드 데이터에서 자동 도출해 항상 시드와 동기화된다.
+ */
+const STATIC_SEED_IMAGE_URL_BY_KEY: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+  for (const detail of demoRoleSeed.jobDetails) {
+    for (const image of detail.images ?? []) {
+      const seedUrl = image.url ?? image.fileUrl;
+      if (seedUrl && !seedUrl.startsWith("/api/demo/uploads")) {
+        map[image.objectKey] = seedUrl;
+      }
+    }
+  }
+  return map;
+})();
+
 function fileUrlForObjectKey(objectKey: string) {
-  return `/api/demo/uploads/${objectKey}`;
+  return STATIC_SEED_IMAGE_URL_BY_KEY[objectKey] ?? `/api/demo/uploads/${objectKey}`;
 }
 
 function normalizeJobImages(images: JobImageMetadata[]): JobImageMetadata[] {

--- a/public/demo-sw.js
+++ b/public/demo-sw.js
@@ -1,0 +1,134 @@
+/*
+ * 데모 모드 전용 Service Worker (무의존, 직접 작성).
+ *
+ * 역할: `/api/demo/uploads/*` 요청만 가로채 업로드 바이너리를 IndexedDB에 영속화하고 서빙한다.
+ *  - PUT/POST : 요청 body(Blob)를 IndexedDB에 저장하고 204를 반환한다.
+ *  - GET      : IndexedDB에서 서빙하고, 없으면 서버 라우트(`fetch`)로 폴백한다.
+ *  - 그 외 경로/메서드는 절대 건드리지 않는다(respondWith 호출 안 함 → 기본 네트워크 동작).
+ *
+ * 스키마는 `lib/demo/persistence.ts`와 반드시 일치해야 한다(같은 스토어를 reset이 비움).
+ *   DB: "demo-uploads" / version 1 / objectStore "blobs" / key = objectKey
+ */
+
+const DB_NAME = "demo-uploads";
+const DB_VERSION = 1;
+const STORE_NAME = "blobs";
+const UPLOAD_PREFIX = "/api/demo/uploads/";
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function idbPut(key, blob) {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readwrite");
+        tx.objectStore(STORE_NAME).put(blob, key);
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+      })
+  );
+}
+
+function idbGet(key) {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly");
+        const req = tx.objectStore(STORE_NAME).get(key);
+        req.onsuccess = () => {
+          db.close();
+          resolve(req.result || null);
+        };
+        req.onerror = () => {
+          db.close();
+          reject(req.error);
+        };
+      })
+  );
+}
+
+/** `/api/demo/uploads/{objectKey}` 에서 objectKey만 추출. 데모 업로드 외 요청은 null. */
+function objectKeyFromUrl(rawUrl) {
+  let pathname;
+  try {
+    pathname = new URL(rawUrl).pathname;
+  } catch {
+    return null;
+  }
+  if (!pathname.startsWith(UPLOAD_PREFIX)) return null;
+  const key = pathname.slice(UPLOAD_PREFIX.length);
+  if (!key) return null;
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+}
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  const key = objectKeyFromUrl(request.url);
+  if (!key) return; // 데모 업로드 외 요청은 기본 네트워크 동작에 맡긴다.
+
+  const method = request.method.toUpperCase();
+
+  if (method === "PUT" || method === "POST") {
+    event.respondWith(
+      request.blob().then(
+        (blob) =>
+          idbPut(key, blob).then(
+            () => new Response(null, { status: 204 }),
+            () => fetch(request) // 저장 실패 시 서버 라우트 폴백
+          ),
+        () => fetch(request)
+      )
+    );
+    return;
+  }
+
+  if (method === "GET") {
+    event.respondWith(
+      idbGet(key).then(
+        (blob) => {
+          if (blob) {
+            return new Response(blob, {
+              status: 200,
+              headers: {
+                "Content-Type": blob.type || "application/octet-stream",
+                "Cache-Control": "no-store",
+              },
+            });
+          }
+          return fetch(request); // IndexedDB에 없으면 서버 라우트 폴백
+        },
+        () => fetch(request)
+      )
+    );
+  }
+});

--- a/utils/__tests__/imageSrc.test.ts
+++ b/utils/__tests__/imageSrc.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isClientServedImage } from "@/utils/imageSrc";
+
+describe("isClientServedImage", () => {
+  it("blob:/data: 클라이언트 메모리 src는 unoptimized 대상이다", () => {
+    expect(isClientServedImage("blob:http://localhost/abc")).toBe(true);
+    expect(isClientServedImage("data:image/png;base64,iVBOR")).toBe(true);
+  });
+
+  it("데모 업로드 경로(쿼리 캐시버스터 포함)는 unoptimized 대상이다", () => {
+    expect(isClientServedImage("/api/demo/uploads/demo/profile-1/photo.png")).toBe(true);
+    expect(isClientServedImage("/api/demo/uploads/demo/profile-1/photo.png?v=123")).toBe(true);
+  });
+
+  it("정적 에셋/외부 https/그 외 값은 최적화를 유지한다", () => {
+    expect(isClientServedImage("/images/default-profile.png")).toBe(false);
+    expect(isClientServedImage("https://lion-connect-files.s3.amazonaws.com/a.png")).toBe(false);
+    expect(isClientServedImage("/api/demo/profile/1")).toBe(false);
+    expect(isClientServedImage(undefined)).toBe(false);
+    expect(isClientServedImage(null)).toBe(false);
+  });
+});

--- a/utils/imageSrc.ts
+++ b/utils/imageSrc.ts
@@ -1,0 +1,14 @@
+/**
+ * Next.js `<Image>` 최적화는 `/_next/image?url=...` 경유로 **서버 사이드에서** src를 fetch한다.
+ * 아래 출처들은 브라우저에만 존재하므로 서버 옵티마이저가 가져올 수 없다 → `unoptimized` 가 필요하다.
+ * (안 그러면 옵티마이저가 빈/없는 리소스를 받아 깨진 이미지 = alt 텍스트가 노출된다.)
+ *
+ * - `blob:` / `data:`     : 클라이언트 메모리 (예: 파일 선택 직후 objectURL 미리보기)
+ * - `/api/demo/uploads/`  : 데모 업로드. Service Worker가 브라우저 IndexedDB에서 서빙한다.
+ *
+ * 매칭되지 않는 src(정적 에셋, 외부 S3 https 등)에는 영향이 없으므로 어디에 적용해도 안전하다.
+ */
+export function isClientServedImage(src: unknown): boolean {
+  if (typeof src !== "string") return false;
+  return src.startsWith("blob:") || src.startsWith("data:") || src.startsWith("/api/demo/uploads/");
+}


### PR DESCRIPTION
## 배경

배포 환경(Vercel 서버리스, 다중 인스턴스)에서는 인메모리 업로드 스토어가 인스턴스 간 공유되지 않아 새로고침 후 업로드 이미지가 사라진다. PR #36에서 데모 데이터를 브라우저 단일 소스로 옮겼고, 이 PR은 그 후속으로 **업로드 바이너리**를 브라우저 IndexedDB에 영속화한다.

## 설계 (핵심)

- **Service Worker가 `/api/demo/uploads/*` 를 네트워크 레벨에서 가로챈다** → `apiClient`·업로드 코드(`uploadThumbnailToS3` raw fetch) **무변경**.
  - PUT/POST: 요청 body(Blob)를 IndexedDB에 저장, 204 반환
  - GET: IndexedDB에서 서빙, 없으면 서버 라우트로 폴백
- IndexedDB 스키마는 `lib/demo/persistence.ts`와 동일(`demo-uploads` / v1 / `blobs`) → `clearDemoBlobs()`(/demo/reset)가 SW가 쓴 blob도 비운다.
- 데모 모드 + `serviceWorker` 지원 시에만 등록, 미지원/실패 시 서버 라우트 폴백으로 graceful degrade.

## 이미지 깨짐(alt 노출) 수정 — next/image 함정

`next/image`는 `/_next/image` 경유로 **서버에서** src를 fetch해 최적화하는데, 데모 업로드 blob은 **브라우저 IndexedDB(SW)에만** 존재해 서버가 못 가져옴 → 깨진 이미지(alt). `blob:`/`data:` objectURL 미리보기도 동일.

- `utils/imageSrc.ts`의 `isClientServedImage()`로 클라이언트 전용 src(`blob:`/`data:`/`/api/demo/uploads/`)는 `unoptimized` 렌더 → 브라우저 직접 요청 → SW가 서빙.
- 적용: `ProfileImageSection`, `IntroduceCard`, `JobImageCarousel`, `JobCard`(job-board), `ImageUpload`. 비매칭 src(정적·외부 https)에는 무영향.

## 첫 페인트 Footer 점프 수정 — /jobs

`/talents`(#1)와 동일 문제: `/jobs` 새로고침 시 Suspense fallback이 빈 컨테이너라 Footer가 먼저 떴다가 밀림. `JobsLoadingState`로 헤더+스켈레톤 3장을 첫 프레임부터 렌더하고 `min-h-screen`으로 높이 예약.

## 변경 파일

- SW: `public/demo-sw.js`, `lib/demo/registerDemoServiceWorker.ts`, `components/demo/DemoServiceWorkerRegistrar.tsx`, `lib/demo/persistence.ts`(스키마 상수 export)
- 이미지: `utils/imageSrc.ts` + 5개 이미지 컴포넌트
- jobs 스켈레톤: `app/(company)/jobs/page.tsx`, `JobsLoadingState.tsx`
- 문서: `docs/demo-uploads-service-worker.md`
- 테스트: 등록 유틸 / 스키마 동기화 / imageSrc / JobsLoadingState

## 검증

- `type-check` / `lint`(max-warnings=0) / `test`(195 passed) ✅
- SW 런타임은 jsdom 단위 테스트 불가 → 등록 유틸 + 스키마 동기화 테스트 + 수동/배포 검증으로 커버(`docs/demo-uploads-service-worker.md` 참고).
- 수동 검증 체크리스트: 썸네일 업로드→새로고침 유지 / 포트폴리오 PDF 유지 / `/demo/reset` 복원 / SW 실패 시 폴백.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
