### PR TITLE
fix: BusinessConnect 해시 스크롤 대기 로직 개선 (#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ CLAUDE.local.md
 
 # personal notes
 notes/
+docs/분석/
 
 # refactor 내부 계획 (결과 요약은 README/docs 로 공개)
 .refactor/

--- a/.plans/business-connect-mutation-observer/plan.md
+++ b/.plans/business-connect-mutation-observer/plan.md
@@ -1,0 +1,41 @@
+# BusinessConnect MutationObserver Scroll
+
+## 무엇을 / 왜
+
+`#business-connect` 해시 진입 시 dynamic import로 섹션 DOM이 늦게 삽입되는 상황을 임의 retry loop가 아니라 DOM 삽입 관찰로 처리한다. 시간 기반 polling 의존도를 줄이고, 실제 DOM 변경 시점에 반응하도록 해 스크롤 동작의 의도를 명확히 한다.
+
+## 현재 상태 진단
+
+- `scrollToBusinessConnectWhenReady`는 80ms 간격으로 최대 20회 `document.getElementById`를 재시도한다.
+- `BusinessConnect`는 `next/dynamic`으로 로드되어 최초 해시 처리 시점에 DOM에 없을 수 있다.
+- `BusinessConnect` wrapper에는 안정적인 관찰 대상 marker가 없어 `document.body` 관찰로 흐르기 쉽다.
+
+## 해결책
+
+- `BusinessConnect` 정적 wrapper에 `data-business-connect-root` marker를 추가한다.
+- `scrollToBusinessConnectWhenReady`를 즉시 시도 후 `MutationObserver`로 root 하위 삽입을 관찰하는 방식으로 변경한다.
+- 성공, timeout, unmount 시 observer와 timeout을 정리하는 cleanup 함수를 반환한다.
+- 기존 호출 방식과 scroll offset/hash update 동작은 유지한다.
+
+## 트레이드오프
+
+| 선택 | 장점 | 단점 |
+|---|---|---|
+| MutationObserver + root marker | DOM 삽입에 즉시 반응하고 관찰 범위가 명확하다 | retry보다 코드가 조금 길다 |
+| timeout fallback 유지 | observer 영구 유지 방지, 기존 최대 대기 UX 보존 | timeout 값 자체는 여전히 정책값이다 |
+
+## 대안
+
+1. **기존 retry loop 유지**
+   - 기각 이유: `20회 * 80ms`처럼 고정된 재시도 횟수는 DOM 삽입 시점과 직접 연결되지 않아 유지보수 근거가 약하다.
+
+2. **`document.body` 전체 관찰**
+   - 기각 이유: 구현은 단순하지만 페이지 전체 mutation에 반응해 관찰 범위가 과하다.
+
+## 완료 기준 (DoD)
+
+- [ ] 섹션이 이미 있으면 observer 없이 즉시 스크롤한다.
+- [ ] 섹션이 root wrapper 안에 나중에 삽입되면 observer callback으로 스크롤한다.
+- [ ] 성공 또는 timeout 시 observer와 timeout이 cleanup 된다.
+- [ ] root marker가 없는 경우에도 body fallback으로 동작한다.
+- [ ] 기존 해시 갱신과 120px offset 계산이 유지된다.

--- a/.plans/business-connect-mutation-observer/task.md
+++ b/.plans/business-connect-mutation-observer/task.md
@@ -1,0 +1,81 @@
+# BusinessConnect MutationObserver Scroll - Task 분할
+
+> 원칙: 각 task는 1개 커밋 단위.
+> plan: [plan.md](./plan.md)
+
+## 본 작업의 스코프
+
+- 포함: BusinessConnect 해시 스크롤 대기 로직, 관찰 root marker, 관련 유틸 테스트
+- 미포함: 디자인/레이아웃 변경, 새 dependency 추가, 다른 해시 스크롤 일반화
+
+## 의존성 순서
+
+```text
+T1 -> T2 -> T3
+```
+
+## T1 - observer 동작 테스트 추가
+
+**보장할 동작**
+
+섹션의 즉시 존재, 지연 삽입, timeout, root fallback 시나리오를 유틸 테스트로 고정한다.
+
+**선행 테스트 / 선행 검증**
+
+`npm test -- lib/__tests__/businessConnectNavigation.test.ts`가 현재 구현에서 실패해야 한다.
+
+**작업**
+
+`businessConnectNavigation` 테스트에 `MutationObserver`와 timer 기반 케이스를 추가한다.
+
+**완료 기준**
+
+새 테스트가 기존 retry 구현에서 red 상태를 만든다.
+
+**커밋**
+
+- `test: cover business connect observer scroll`
+
+## T2 - MutationObserver 구현
+
+**보장할 동작**
+
+`scrollToBusinessConnectWhenReady`가 즉시 시도 후 root wrapper를 관찰하고 cleanup 함수를 반환한다.
+
+**선행 테스트 / 선행 검증**
+
+T1 테스트 red 확인.
+
+**작업**
+
+`lib/businessConnectNavigation.ts`를 observer 기반으로 변경하고 root marker 상수를 추가한다.
+
+**완료 기준**
+
+`npm test -- lib/__tests__/businessConnectNavigation.test.ts`가 green이다.
+
+**커밋**
+
+- `fix: observe business connect section before scrolling`
+
+## T3 - root marker와 effect cleanup 연결
+
+**보장할 동작**
+
+BusinessConnect 정적 wrapper만 관찰 대상으로 사용할 수 있고, 최초 해시 처리 effect가 unmount 시 cleanup 한다.
+
+**선행 테스트 / 선행 검증**
+
+유틸 테스트 green.
+
+**작업**
+
+홈 페이지 wrapper에 marker를 추가하고 `ScrollToHash`에서 cleanup을 반환한다.
+
+**완료 기준**
+
+관련 테스트, type-check, lint가 통과한다.
+
+**커밋**
+
+- `chore: wire business connect scroll cleanup`

--- a/app/(company)/page.tsx
+++ b/app/(company)/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
         </div>
       </article>
 
-      <div className="pt-60 pb-[127px]">
+      <div data-business-connect-root className="pt-60 pb-[127px]">
         <BusinessConnect />
       </div>
     </main>

--- a/components/ScrollToHash.tsx
+++ b/components/ScrollToHash.tsx
@@ -14,13 +14,18 @@ import {
  */
 export default function ScrollToHash() {
   useEffect(() => {
+    let cleanupBusinessConnectScroll: (() => void) | undefined;
+    let scrollDelayTimeoutId: number | undefined;
+
     // 페이지 로드 시 해시가 있으면 해당 섹션으로 스크롤
     const hash = window.location.hash;
     if (hash) {
       // 약간의 지연을 주어 페이지가 완전히 로드된 후 스크롤
-      setTimeout(() => {
+      scrollDelayTimeoutId = window.setTimeout(() => {
         if (hash === BUSINESS_CONNECT_HASH) {
-          scrollToBusinessConnectWhenReady({ behavior: SCROLL_BEHAVIOR });
+          cleanupBusinessConnectScroll = scrollToBusinessConnectWhenReady({
+            behavior: SCROLL_BEHAVIOR,
+          });
           return;
         }
 
@@ -33,6 +38,13 @@ export default function ScrollToHash() {
         }
       }, SCROLL_DELAY_MS);
     }
+
+    return () => {
+      if (scrollDelayTimeoutId !== undefined) {
+        window.clearTimeout(scrollDelayTimeoutId);
+      }
+      cleanupBusinessConnectScroll?.();
+    };
   }, []);
 
   return null;

--- a/lib/__tests__/businessConnectNavigation.test.ts
+++ b/lib/__tests__/businessConnectNavigation.test.ts
@@ -1,11 +1,51 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BUSINESS_CONNECT_ID,
   BUSINESS_CONNECT_HREF,
+  BUSINESS_CONNECT_ROOT_SELECTOR,
   BUSINESS_CONNECT_SCROLL_OFFSET,
+  BUSINESS_CONNECT_SCROLL_TIMEOUT_MS,
   getBusinessConnectScrollTop,
+  scrollToBusinessConnectWhenReady,
 } from "@/lib/businessConnectNavigation";
 
 describe("businessConnectNavigation", () => {
+  let observeMock: ReturnType<typeof vi.fn>;
+  let disconnectMock: ReturnType<typeof vi.fn>;
+  let mutationCallback: MutationCallback | undefined;
+  let originalMutationObserver: typeof MutationObserver;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+
+    observeMock = vi.fn();
+    disconnectMock = vi.fn();
+    mutationCallback = undefined;
+    originalMutationObserver = window.MutationObserver;
+
+    class MockMutationObserver {
+      constructor(callback: MutationCallback) {
+        mutationCallback = callback;
+      }
+
+      observe = observeMock;
+      disconnect = disconnectMock;
+      takeRecords = vi.fn();
+    }
+
+    window.MutationObserver = MockMutationObserver as unknown as typeof MutationObserver;
+  });
+
+  afterEach(() => {
+    window.MutationObserver = originalMutationObserver;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
   it("uses the business connect hash href", () => {
     expect(BUSINESS_CONNECT_HREF).toBe("/#business-connect");
   });
@@ -26,5 +66,50 @@ describe("businessConnectNavigation", () => {
     } as Element;
 
     expect(getBusinessConnectScrollTop(element, 0)).toBe(0);
+  });
+
+  it("scrolls immediately without creating an observer when the section exists", () => {
+    document.body.innerHTML = `<section id="${BUSINESS_CONNECT_ID}"></section>`;
+
+    const cleanup = scrollToBusinessConnectWhenReady({ behavior: "auto" });
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "auto" });
+    expect(window.history.replaceState).toHaveBeenCalledWith(null, "", BUSINESS_CONNECT_HREF);
+    expect(observeMock).not.toHaveBeenCalled();
+
+    cleanup();
+    expect(disconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("observes the business connect root and scrolls when the section is inserted", () => {
+    document.body.innerHTML = `<div data-business-connect-root></div>`;
+    const root = document.querySelector(BUSINESS_CONNECT_ROOT_SELECTOR);
+
+    scrollToBusinessConnectWhenReady({ behavior: "auto" });
+
+    expect(observeMock).toHaveBeenCalledWith(root, { childList: true, subtree: true });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+
+    root?.insertAdjacentHTML("beforeend", `<section id="${BUSINESS_CONNECT_ID}"></section>`);
+    mutationCallback?.([], {} as MutationObserver);
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "auto" });
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects the observer when the section is not inserted before timeout", () => {
+    document.body.innerHTML = `<div data-business-connect-root></div>`;
+
+    scrollToBusinessConnectWhenReady({ behavior: "auto" });
+    vi.advanceTimersByTime(BUSINESS_CONNECT_SCROLL_TIMEOUT_MS);
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to observing document.body when the business connect root is missing", () => {
+    scrollToBusinessConnectWhenReady({ behavior: "auto" });
+
+    expect(observeMock).toHaveBeenCalledWith(document.body, { childList: true, subtree: true });
   });
 });

--- a/lib/businessConnectNavigation.ts
+++ b/lib/businessConnectNavigation.ts
@@ -1,9 +1,10 @@
 export const BUSINESS_CONNECT_ID = "business-connect";
 export const BUSINESS_CONNECT_HASH = `#${BUSINESS_CONNECT_ID}`;
 export const BUSINESS_CONNECT_HREF = `/${BUSINESS_CONNECT_HASH}`;
+export const BUSINESS_CONNECT_ROOT_ATTRIBUTE = "data-business-connect-root";
+export const BUSINESS_CONNECT_ROOT_SELECTOR = `[${BUSINESS_CONNECT_ROOT_ATTRIBUTE}]`;
 export const BUSINESS_CONNECT_SCROLL_OFFSET = 120;
-export const BUSINESS_CONNECT_SCROLL_RETRY_DELAY_MS = 80;
-export const BUSINESS_CONNECT_SCROLL_MAX_ATTEMPTS = 20;
+export const BUSINESS_CONNECT_SCROLL_TIMEOUT_MS = 1600;
 
 type ScrollToBusinessConnectOptions = {
   behavior?: ScrollBehavior;
@@ -12,8 +13,7 @@ type ScrollToBusinessConnectOptions = {
 };
 
 type ScrollWhenReadyOptions = ScrollToBusinessConnectOptions & {
-  maxAttempts?: number;
-  retryDelayMs?: number;
+  timeoutMs?: number;
 };
 
 export function getBusinessConnectScrollTop(
@@ -46,22 +46,35 @@ export function scrollToBusinessConnect({
 }
 
 export function scrollToBusinessConnectWhenReady({
-  maxAttempts = BUSINESS_CONNECT_SCROLL_MAX_ATTEMPTS,
-  retryDelayMs = BUSINESS_CONNECT_SCROLL_RETRY_DELAY_MS,
+  timeoutMs = BUSINESS_CONNECT_SCROLL_TIMEOUT_MS,
   ...scrollOptions
 }: ScrollWhenReadyOptions = {}) {
-  let attempts = 0;
+  if (scrollToBusinessConnect(scrollOptions)) return () => {};
 
-  const tryScroll = () => {
-    if (scrollToBusinessConnect(scrollOptions)) return;
+  const root = document.querySelector(BUSINESS_CONNECT_ROOT_SELECTOR) ?? document.body;
+  if (!root) return () => {};
 
-    attempts += 1;
-    if (attempts < maxAttempts) {
-      window.setTimeout(tryScroll, retryDelayMs);
+  let isCleanedUp = false;
+
+  const observer = new window.MutationObserver(() => {
+    if (scrollToBusinessConnect(scrollOptions)) {
+      cleanup();
     }
+  });
+
+  const cleanup = () => {
+    if (isCleanedUp) return;
+
+    isCleanedUp = true;
+    observer.disconnect();
+    window.clearTimeout(timeoutId);
   };
 
-  tryScroll();
+  const timeoutId = window.setTimeout(cleanup, timeoutMs);
+
+  observer.observe(root, { childList: true, subtree: true });
+
+  return cleanup;
 }
 
 export function clearBusinessConnectHash(onHashChange?: (hash: string) => void) {


### PR DESCRIPTION
Closes #39

## 요약

`#business-connect` 해시 진입 시 dynamic import로 섹션 DOM이 늦게 삽입되는 상황을 `MutationObserver` 기반으로 처리하도록 변경했습니다.

## 변경 사항

- `BusinessConnect` 정적 wrapper에 `data-business-connect-root` marker를 추가했습니다.
- `scrollToBusinessConnectWhenReady`를 즉시 시도 후 root 하위 DOM 삽입을 관찰하는 방식으로 변경했습니다.
- 성공, timeout, unmount 시 observer와 timeout을 정리하도록 cleanup을 연결했습니다.
- `docs/분석/` 개인 분석 폴더를 `.gitignore`에 추가했습니다.
- observer 동작, timeout cleanup, body fallback 테스트를 추가했습니다.

## 검증

- [x] `npm test -- lib/__tests__/businessConnectNavigation.test.ts`
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test`