### PR TITLE
refactor: API 호출 계층 정합성 (withQuery / apiRawRequest / parseResponse) (#41)

### DIFF
--- a/.plans/api-layer-refactor/plan.md
+++ b/.plans/api-layer-refactor/plan.md
@@ -59,13 +59,13 @@
 
 ## 완료 기준 (DoD)
 
-- [ ] `withQuery` 유틸 + 단위 테스트(undefined 생략/배열 반복/빈 배열 처리) 통과
-- [ ] 5개 도메인 파일이 `withQuery` 사용, 생성되는 query string이 변경 전과 동일
-- [ ] `parseResponse` 추출, 정상·재시도 경로 공유, 204/빈 응답/JSON 파싱 테스트 통과
-- [ ] `apiRawRequest` 추가 + 테스트(헤더 접근 가능, timeout/네트워크 에러가 `ApiError`로 변환)
-- [ ] `refreshAccessToken`·`loginAPI`가 `apiRawRequest` 사용, `loginAPI` 실패 시 `ApiError`
-- [ ] `npm run type-check`, `npm run lint`, `npm run test` 녹색
-- [ ] `docs/분석/`에 전/후 설명 문서 작성
-- [ ] 포폴 발표용 회고 슬라이드 초안 작성(Before 1장 + 회고 1장)
+- [x] `withQuery` 유틸 + 단위 테스트(undefined 생략/배열 반복/빈 배열 처리) 통과
+- [x] 5개 도메인 파일이 `withQuery` 사용, 생성되는 query string이 변경 전과 동일
+- [x] `parseResponse` 추출, 정상·재시도 경로 공유, 204/빈 응답/JSON 파싱 테스트 통과
+- [x] `apiRawRequest` 추가 + 테스트(헤더 접근 가능, timeout/네트워크 에러가 `ApiError`로 변환)
+- [x] `refreshAccessToken`·`loginAPI`가 `apiRawRequest` 사용, `loginAPI` 실패 시 `ApiError`
+- [x] `npm run type-check`, `npm run lint`, `npm run test` 녹색 (239 tests)
+- [x] `docs/분석/`에 전/후 설명 문서 작성
+- [x] 포폴 발표용 회고 슬라이드 초안 작성(Before 1장 + 회고 1장)
 - [ ] `.agents/evaluation.md` Stage 1/2 통과
 ```

--- a/.plans/api-layer-refactor/plan.md
+++ b/.plans/api-layer-refactor/plan.md
@@ -1,0 +1,71 @@
+# API 호출 계층 정합성 리팩토링
+
+> 근거 분석: [docs/분석/API-호출-계층화-설계-분석.md](../../docs/분석/API-호출-계층화-설계-분석.md)
+> Level: 2 (점수 7/12, 강제 승격: 리팩토링/공용 유틸/인증)
+
+## 무엇을 / 왜
+
+현재 3계층 구조(`constants/api.ts` + `lib/apiClient.ts` + `lib/api/*`)는 방향이 옳지만,
+"공통 관심사는 apiClient에 한 번만 구현된다"는 설계 원칙이 코드에서 일부 깨져 있다.
+
+- query string 조립(`URLSearchParams`)이 도메인 함수 5개 파일에 거의 복붙으로 반복된다.
+- 백엔드 API인 `loginAPI`·`refreshAccessToken`이 공통 클라이언트를 우회해 직접 `fetch`를 쓴다.
+  특히 `loginAPI`는 `ApiError`가 아닌 일반 `Error`를 던져 에러 타입이 일관되지 않는다.
+- `apiRequest` 내부의 응답 파싱 로직이 정상 경로(354-386)와 401 재시도 경로(316-342)에 통째로 중복돼 있다.
+
+이 리팩토링의 목표는 새 구조 도입이 아니라 **기존 구조의 원칙을 코드와 일치시키는 것**이다.
+외부 동작(API 요청/응답 결과)은 바꾸지 않는다.
+
+## 현재 상태 진단
+
+- `lib/api/jobPostings.ts`: `fetchPublicJobPostings`, `fetchJobApplicants`, `fetchAdminJobPostings`,
+  `fetchAdminJobApplicants` 4개 함수가 page/size/sort 조립을 각자 반복.
+- `lib/api/serverJobPostings.ts`, `adminUsers.ts`, `inquiries.ts`, `talents.ts`도 동일 패턴 반복.
+- `lib/apiClient.ts:178` `refreshAccessToken`: 직접 `fetch` + 자체 에러 처리(timeout/ApiError 우회).
+- `lib/api/auth.ts:34` `loginAPI`: 직접 `fetch`, 응답 헤더(`Authorization`) 접근 위해 raw 필요.
+  실패 시 `throw new Error(...)` → UI의 `instanceof ApiError` 분기에서 누락됨.
+- `lib/apiClient.ts:316-342` vs `354-386`: 204/빈 응답/JSON 파싱 로직이 두 번 거의 동일하게 존재.
+- S3 presigned 업로드 4곳(`profilePortfolio`, `profileResume`, `profileThumbnail`, `jobPostings`)은
+  외부 URL이므로 **흡수 대상에서 제외**(현 상태 유지).
+
+## 해결책
+
+- `lib/http/query.ts`에 `withQuery(endpoint, params)` 유틸 추가. `undefined`/빈 배열은 생략,
+  배열은 반복 append(sort 등), 기존 동작과 1:1 동일하게. 5개 파일에 적용.
+- `lib/apiClient.ts`에 `parseResponse<T>(response)` 내부 함수 추출 → 정상/재시도 경로 공유.
+- `lib/apiClient.ts`에 `apiRawRequest(endpoint, options): Promise<Response>` 추가.
+  base URL/timeout/demo URL resolution/`ApiError` 네트워크·타임아웃 변환은 공유하되 응답 본문은 파싱하지 않고 raw `Response` 반환.
+- `refreshAccessToken`과 `loginAPI`를 `apiRawRequest` 위로 이전. `loginAPI` 실패 경로를 `ApiError`로 통일.
+- 변경 근거와 전/후를 `docs/분석/`에 설명 문서로 작성.
+
+## 트레이드오프
+
+| 선택 | 장점 | 단점 |
+|---|---|---|
+| `withQuery` 공통 유틸 도입 | 5개 파일 중복 제거, 규칙 1곳 관리 | 얇은 추상화 1개 추가, 각 호출부 가독성은 약간 암묵적 |
+| `apiRawRequest`로 raw fetch 흡수 | 인증 경로도 공통 정책(timeout/error/demo) 공유, 에러 타입 통일 | apiClient 표면적 1개 증가, login/refresh 동작 회귀 위험 → 테스트로 방어 |
+| `parseResponse` 추출 | 파싱 규칙 1곳, 재시도 경로 drift 제거 | apiRequest 내부 호출 흐름 한 단계 추가 |
+
+## 대안
+
+1. **현 상태 유지(아무것도 안 함)**
+   - 기각 이유: 포폴 문구("공통 관심사는 한 번만 구현")가 코드와 불일치. `loginAPI` 에러 타입 불일치는 실제 버그 리스크.
+
+2. **도메인별 폴더 분리 + queryKeys까지 재구성(분석 문서의 "중규모" 안)**
+   - 기각 이유: 현재 규모에 과함. 외부 동작 변화 없는 정합성 작업 범위를 넘어 위험·비용이 큼. 분석 문서도 "나중"으로 분류.
+
+3. **`apiRawRequest` 없이 login/refresh를 그대로 두고 query 유틸만 적용**
+   - 기각 이유: 가장 실질적 리스크(에러 타입 불일치)를 남김. 포폴 서사의 핵심("우회 경로 흡수")도 약해짐.
+
+## 완료 기준 (DoD)
+
+- [ ] `withQuery` 유틸 + 단위 테스트(undefined 생략/배열 반복/빈 배열 처리) 통과
+- [ ] 5개 도메인 파일이 `withQuery` 사용, 생성되는 query string이 변경 전과 동일
+- [ ] `parseResponse` 추출, 정상·재시도 경로 공유, 204/빈 응답/JSON 파싱 테스트 통과
+- [ ] `apiRawRequest` 추가 + 테스트(헤더 접근 가능, timeout/네트워크 에러가 `ApiError`로 변환)
+- [ ] `refreshAccessToken`·`loginAPI`가 `apiRawRequest` 사용, `loginAPI` 실패 시 `ApiError`
+- [ ] `npm run type-check`, `npm run lint`, `npm run test` 녹색
+- [ ] `docs/분석/`에 전/후 설명 문서 작성
+- [ ] 포폴 발표용 회고 슬라이드 초안 작성(Before 1장 + 회고 1장)
+- [ ] `.agents/evaluation.md` Stage 1/2 통과
+```

--- a/.plans/api-layer-refactor/task.md
+++ b/.plans/api-layer-refactor/task.md
@@ -1,0 +1,129 @@
+# API 호출 계층 정합성 리팩토링 - Task 분할
+
+> 원칙: 각 task는 1개 커밋 단위. 새 코드/리팩토링은 실패 테스트 → green → refactor 순.
+> plan: [plan.md](./plan.md)
+
+## 본 작업의 스코프
+
+- 포함: query string 유틸, 응답 파싱 중복 제거, raw fetch 흡수(login/refresh), 설명 문서 + 회고 슬라이드
+- 미포함: 도메인 폴더 분리, queryKeys 재구성, OpenAPI 생성, S3 업로드 fetch, `serverApiClient` 변경, 외부 API 동작 변경
+
+## 의존성 순서
+
+```text
+T1 -> T2 -> T3 -> T4 -> T5 -> T6
+```
+
+T3는 T1/T2와 독립이지만 같은 흐름 유지를 위해 순서대로 진행.
+
+## T1 - `withQuery` 쿼리 스트링 유틸 추가
+
+**보장할 동작**
+- `undefined`/`null` 값은 query에서 생략
+- 배열 값은 같은 key로 반복 append (sort 등)
+- 빈 배열은 생략, 숫자는 문자열로 직렬화
+- params 없으면 endpoint 그대로 반환(`?` 미부착)
+
+**선행 테스트 / 선행 검증**
+- `lib/http/__tests__/query.test.ts`: 위 4개 동작에 대한 실패 테스트 먼저 작성
+
+**작업**
+- `lib/http/query.ts`에 `withQuery(endpoint, params)` 구현
+
+**완료 기준**
+- query 테스트 green, `npm run type-check` 통과
+
+**커밋**
+- `feat: add withQuery helper for query string assembly`
+
+## T2 - 도메인 함수에 `withQuery` 적용
+
+**보장할 동작**
+- 적용 전후 생성되는 query string이 **완전히 동일** (page/size/sort/status/jobGroupCode 등 순서·생략 규칙 보존)
+
+**선행 테스트 / 선행 검증**
+- 적용 전 각 함수가 만드는 URL을 스냅샷성 단위 테스트로 고정(가능 범위), 또는 적용 후 동일 입력→동일 string 비교 테스트
+
+**작업**
+- `jobPostings.ts`(4곳), `serverJobPostings.ts`, `adminUsers.ts`, `inquiries.ts`, `talents.ts`를 `withQuery`로 치환
+
+**완료 기준**
+- 관련 테스트 green, `npm run test`/`type-check`/`lint` 통과
+
+**커밋**
+- `refactor: use withQuery in domain api functions`
+
+## T3 - `parseResponse` 추출 (응답 파싱 중복 제거)
+
+**보장할 동작**
+- 204 → `{}`, content-length 0/비 JSON → 빈 객체 또는 JSON 파싱, JSON 파싱 실패 → `{}`
+- 정상 경로와 401 재시도 경로가 **동일한** 파싱 로직 공유
+
+**선행 테스트 / 선행 검증**
+- `lib/__tests__/apiClient.parseResponse.test.ts`: 204/빈/정상 JSON/깨진 JSON 케이스 실패 테스트 먼저
+
+**작업**
+- `apiClient.ts`에 `parseResponse<T>(response): Promise<T>` 내부 함수 추출 후 두 경로에서 호출
+
+**완료 기준**
+- 파싱 테스트 green, 기존 동작 회귀 없음
+
+**커밋**
+- `refactor: extract parseResponse to dedupe response parsing`
+
+## T4 - `apiRawRequest` 추가
+
+**보장할 동작**
+- base URL/timeout/demo URL resolution/네트워크·타임아웃 `ApiError` 변환은 공유
+- 응답 본문은 파싱하지 않고 raw `Response` 반환 → 호출부가 헤더 접근 가능
+- `skipAuth` 옵션 지원(login은 토큰 불필요)
+
+**선행 테스트 / 선행 검증**
+- `lib/__tests__/apiClient.rawRequest.test.ts`: 헤더 접근 가능, AbortError→TIMEOUT, TypeError→NETWORK_ERROR 변환 실패 테스트 먼저 (`fetch` mock)
+
+**작업**
+- `apiClient.ts`에 `apiRawRequest(endpoint, options): Promise<Response>` 구현(공통 부분 `fetchWithTimeout` 재사용)
+
+**완료 기준**
+- raw 테스트 green, `type-check` 통과
+
+**커밋**
+- `feat: add apiRawRequest for raw response access`
+
+## T5 - login/refresh를 `apiRawRequest`로 이전 + 에러 타입 통일
+
+**보장할 동작**
+- 로그인 성공: `Authorization` 헤더에서 토큰 추출, user 검증 동작 유지
+- 로그인 실패: `ApiError`로 통일 (기존 `throw new Error` 제거)
+- refresh: 기존 토큰 추출(헤더 우선, body 폴백)·중복 방지·실패 시 `clearAuth` 동작 유지
+
+**선행 테스트 / 선행 검증**
+- `lib/api/__tests__/auth.login.test.ts`: 성공 토큰 추출 / 실패 시 `instanceof ApiError` 실패 테스트 먼저
+- refresh는 회귀 방지 테스트(성공/401 실패) 추가
+
+**작업**
+- `loginAPI`, `refreshAccessToken`을 `apiRawRequest` 기반으로 재작성
+
+**완료 기준**
+- 인증 테스트 green, 로그인/새로고침 수동 확인(데모 모드 무영향), 전체 `test`/`type-check`/`lint` 통과
+
+**커밋**
+- `refactor: route login/refresh through apiRawRequest`
+
+## T6 - 설명 문서 + 회고 슬라이드
+
+**보장할 동작**
+- 문서는 실제 변경(전/후 코드, 커밋 근거)과 일치. TanStack Query 사용 사실 정확히 반영
+
+**선행 검증**
+- T1~T5 diff 기준으로 작성, 추측 금지
+
+**작업**
+- `docs/분석/API-호출-계층-정합성-리팩토링.md`: 문제 → 변경 → 판단 근거 → 남은 과제
+- `docs/포폴/api-layer-slides.md`: Before 슬라이드 1장 + 회고 슬라이드 1장
+
+**완료 기준**
+- 문서/슬라이드 내 수치·파일·동작이 실제 코드와 일치
+
+**커밋**
+- `docs: add api layer refactor writeup and retro slides`

--- a/lib/__tests__/apiClient.parseResponse.test.ts
+++ b/lib/__tests__/apiClient.parseResponse.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseResponse } from "@/lib/apiClient";
+
+const jsonResponse = (body: string, status = 200) =>
+  new Response(body, { status, headers: { "content-type": "application/json" } });
+
+describe("parseResponse", () => {
+  it("returns empty object for 204 No Content", async () => {
+    const res = new Response(null, { status: 204 });
+    await expect(parseResponse(res)).resolves.toEqual({});
+  });
+
+  it("returns empty object when content-length is 0", async () => {
+    const res = new Response("", {
+      status: 200,
+      headers: { "content-length": "0", "content-type": "application/json" },
+    });
+    await expect(parseResponse(res)).resolves.toEqual({});
+  });
+
+  it("returns empty object for non-JSON empty body", async () => {
+    const res = new Response("", { status: 200, headers: { "content-type": "text/plain" } });
+    await expect(parseResponse(res)).resolves.toEqual({});
+  });
+
+  it("parses JSON text even when content-type is not application/json", async () => {
+    const res = new Response(JSON.stringify({ a: 1 }), {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+    await expect(parseResponse(res)).resolves.toEqual({ a: 1 });
+  });
+
+  it("parses a normal application/json body", async () => {
+    await expect(parseResponse(jsonResponse(JSON.stringify({ ok: true })))).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("returns empty object when JSON body is broken", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(parseResponse(jsonResponse("{not-json"))).resolves.toEqual({});
+    warn.mockRestore();
+  });
+});

--- a/lib/__tests__/apiClient.rawRequest.test.ts
+++ b/lib/__tests__/apiClient.rawRequest.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth } = vi.hoisted(() => ({
+  mockAuth: { accessToken: null as string | null, user: null as unknown },
+}));
+
+vi.mock("@/store/authStore", () => ({
+  useAuthStore: { getState: () => mockAuth },
+}));
+
+import { apiRawRequest, ApiError } from "@/lib/apiClient";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  mockAuth.accessToken = null;
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("apiRawRequest", () => {
+  it("returns the raw Response so response headers are accessible", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ user: {} }), {
+        status: 200,
+        headers: { Authorization: "Bearer issued-token" },
+      })
+    );
+
+    const res = await apiRawRequest("/auth/login", { method: "POST", skipAuth: true });
+
+    expect(res.headers.get("Authorization")).toBe("Bearer issued-token");
+    expect(fetchMock.mock.calls[0][0] as string).toContain("/auth/login");
+  });
+
+  it("injects Authorization header when token exists and skipAuth is not set", async () => {
+    mockAuth.accessToken = "tok";
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await apiRawRequest("/whatever", { method: "GET" });
+
+    const init = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(init.headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("omits Authorization when skipAuth is true", async () => {
+    mockAuth.accessToken = "tok";
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await apiRawRequest("/auth/login", { method: "POST", skipAuth: true });
+
+    const init = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it("maps AbortError to ApiError with TIMEOUT code", async () => {
+    fetchMock.mockRejectedValue(Object.assign(new Error("aborted"), { name: "AbortError" }));
+
+    await expect(apiRawRequest("/x")).rejects.toBeInstanceOf(ApiError);
+    await expect(apiRawRequest("/x")).rejects.toMatchObject({ code: "TIMEOUT" });
+  });
+
+  it("maps network TypeError to ApiError with NETWORK_ERROR code", async () => {
+    fetchMock.mockRejectedValue(new TypeError("network down"));
+
+    await expect(apiRawRequest("/x")).rejects.toMatchObject({ code: "NETWORK_ERROR" });
+  });
+});

--- a/lib/api/__tests__/auth.login.test.ts
+++ b/lib/api/__tests__/auth.login.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth } = vi.hoisted(() => ({
+  mockAuth: { accessToken: null as string | null, user: null as unknown },
+}));
+
+vi.mock("@/store/authStore", () => ({
+  useAuthStore: { getState: () => mockAuth },
+}));
+
+import { loginAPI } from "@/lib/api/auth";
+import { ApiError } from "@/lib/apiClient";
+
+const fetchMock = vi.fn();
+const jsonHeaders = (extra: Record<string, string> = {}) => ({
+  "content-type": "application/json",
+  ...extra,
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+const credentials = { email: "a@b.c", password: "pw" };
+
+describe("loginAPI", () => {
+  it("extracts the access token from the Authorization header on success", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: 1, email: "a@b.c" } }), {
+        status: 200,
+        headers: jsonHeaders({ Authorization: "Bearer issued-token" }),
+      })
+    );
+
+    const res = await loginAPI(credentials);
+
+    expect(res.accessToken).toBe("issued-token");
+    expect(res.user).toEqual({ id: 1, email: "a@b.c" });
+    expect(fetchMock.mock.calls[0][0] as string).toContain("/auth/login");
+  });
+
+  it("throws ApiError (not a plain Error) when the response is not ok", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ message: "비밀번호가 틀렸습니다" }), {
+        status: 401,
+        headers: jsonHeaders(),
+      })
+    );
+
+    await expect(loginAPI(credentials)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("throws ApiError when no access token is returned", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: 1 } }), {
+        status: 200,
+        headers: jsonHeaders(),
+      })
+    );
+
+    await expect(loginAPI(credentials)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("throws ApiError when user info is missing", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: jsonHeaders({ Authorization: "Bearer issued-token" }),
+      })
+    );
+
+    await expect(loginAPI(credentials)).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/lib/api/__tests__/queryParams.test.ts
+++ b/lib/api/__tests__/queryParams.test.ts
@@ -1,0 +1,136 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+/**
+ * 도메인 API 함수의 query string 보존을 고정하는 characterization 테스트.
+ * withQuery 리팩토링 전/후 모두 동일한 endpoint를 만들어야 한다.
+ */
+
+const getMock = vi.fn().mockResolvedValue({});
+const serverGetMock = vi.fn().mockResolvedValue({});
+
+vi.mock("@/lib/apiClient", () => ({
+  get: (...args: unknown[]) => getMock(...args),
+  post: vi.fn().mockResolvedValue({}),
+  put: vi.fn().mockResolvedValue({}),
+  del: vi.fn().mockResolvedValue({}),
+  patch: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/serverApiClient", () => ({
+  serverGet: (...args: unknown[]) => serverGetMock(...args),
+}));
+
+import {
+  fetchPublicJobPostings,
+  fetchJobApplicants,
+  fetchAdminJobPostings,
+  fetchAdminJobApplicants,
+} from "@/lib/api/jobPostings";
+import { fetchPublicJobPostingsServer } from "@/lib/api/serverJobPostings";
+import { fetchTalents } from "@/lib/api/talents";
+import { fetchAdminUsers, fetchAdminCompanies } from "@/lib/api/adminUsers";
+import { getAdminInquiries } from "@/lib/api/inquiries";
+
+const lastGetEndpoint = () => getMock.mock.calls.at(-1)?.[0] as string;
+const lastServerGetEndpoint = () => serverGetMock.mock.calls.at(-1)?.[0] as string;
+
+beforeEach(() => {
+  getMock.mockClear();
+  serverGetMock.mockClear();
+});
+
+describe("jobPostings query params", () => {
+  it("fetchPublicJobPostings: jobGroupCode, jobRoleCode, page, size, sort 순서 보존", async () => {
+    await fetchPublicJobPostings({
+      jobGroupCode: "DEV",
+      jobRoleCode: "FE",
+      page: 0,
+      size: 10,
+      sort: ["createdAt,desc"],
+    });
+    expect(lastGetEndpoint()).toBe(
+      "/job-postings?jobGroupCode=DEV&jobRoleCode=FE&page=0&size=10&sort=createdAt%2Cdesc"
+    );
+  });
+
+  it("fetchJobApplicants: page, size, sort", async () => {
+    await fetchJobApplicants("5", { page: 1, size: 20, sort: ["id,asc"] });
+    expect(lastGetEndpoint()).toBe(
+      "/company/job-postings/5/applications?page=1&size=20&sort=id%2Casc"
+    );
+  });
+
+  it("fetchAdminJobPostings: status='' 를 맨 앞에 포함", async () => {
+    await fetchAdminJobPostings({ page: 0, size: 10 });
+    expect(lastGetEndpoint()).toBe("/admin/job-postings?status=&page=0&size=10");
+  });
+
+  it("fetchAdminJobApplicants: page, size", async () => {
+    await fetchAdminJobApplicants("7", { page: 0, size: 5 });
+    expect(lastGetEndpoint()).toBe("/admin/job-postings/7/applications?page=0&size=5");
+  });
+});
+
+describe("serverJobPostings query params", () => {
+  it("fetchPublicJobPostingsServer: 동일 규칙", async () => {
+    await fetchPublicJobPostingsServer({
+      jobGroupCode: "DEV",
+      page: 2,
+      size: 12,
+      sort: ["createdAt,desc"],
+    });
+    expect(lastServerGetEndpoint()).toBe(
+      "/job-postings?jobGroupCode=DEV&page=2&size=12&sort=createdAt%2Cdesc"
+    );
+  });
+});
+
+describe("talents query params", () => {
+  it("fetchTalents: page, size, jobGroupId, jobRoleId, keyword(trim)", async () => {
+    await fetchTalents({ page: 0, size: 20, jobGroupId: 1, jobRoleId: 2, keyword: "  hi  " });
+    expect(lastGetEndpoint()).toBe(
+      "/profiles/search?page=0&size=20&jobGroupId=1&jobRoleId=2&keyword=hi"
+    );
+  });
+
+  it("fetchTalents: 공백뿐인 keyword는 생략", async () => {
+    await fetchTalents({ page: 1, size: 5, keyword: "   " });
+    expect(lastGetEndpoint()).toBe("/profiles/search?page=1&size=5");
+  });
+});
+
+describe("adminUsers query params", () => {
+  it("fetchAdminUsers: page, size", async () => {
+    await fetchAdminUsers({ page: 1, size: 30 });
+    expect(lastGetEndpoint()).toBe("/admin/users?page=1&size=30");
+  });
+
+  it("fetchAdminCompanies: page, size, sort(있을 때만)", async () => {
+    await fetchAdminCompanies({ page: 0, size: 20, sort: "name,asc" });
+    expect(lastGetEndpoint()).toBe("/admin/companies?page=0&size=20&sort=name%2Casc");
+  });
+
+  it("fetchAdminCompanies: sort 없으면 생략", async () => {
+    await fetchAdminCompanies({ page: 0, size: 20 });
+    expect(lastGetEndpoint()).toBe("/admin/companies?page=0&size=20");
+  });
+});
+
+describe("inquiries query params", () => {
+  it("getAdminInquiries: status, page, size, sort", async () => {
+    await getAdminInquiries({
+      status: "IN_PROGRESS",
+      page: 0,
+      size: 10,
+      sort: ["receivedAt,desc"],
+    });
+    expect(lastGetEndpoint()).toBe(
+      "/admin/inquiries?status=IN_PROGRESS&page=0&size=10&sort=receivedAt%2Cdesc"
+    );
+  });
+
+  it("getAdminInquiries: 파라미터 없으면 query string 없음", async () => {
+    await getAdminInquiries();
+    expect(lastGetEndpoint()).toBe("/admin/inquiries");
+  });
+});

--- a/lib/api/adminUsers.ts
+++ b/lib/api/adminUsers.ts
@@ -2,6 +2,7 @@
 
 import { API_ENDPOINTS } from "@/constants/api";
 import { get, post, del } from "@/lib/apiClient";
+import { withQuery } from "@/lib/http/query";
 import { AdminUsersResponse, AdminCompaniesResponse, ProfileLockResponse } from "@/types/admin";
 
 /**
@@ -20,12 +21,7 @@ export async function fetchAdminUsers({
   page = 0,
   size = 20,
 }: FetchAdminUsersParams = {}): Promise<AdminUsersResponse> {
-  const params = new URLSearchParams();
-
-  params.set("page", String(page));
-  params.set("size", String(size));
-
-  const url = `${API_ENDPOINTS.ADMIN.USERS.LIST}?${params.toString()}`;
+  const url = withQuery(API_ENDPOINTS.ADMIN.USERS.LIST, { page, size });
 
   return get<AdminUsersResponse>(url);
 }
@@ -82,15 +78,11 @@ export async function fetchAdminCompanies({
   size = 20,
   sort,
 }: FetchAdminCompaniesParams = {}): Promise<AdminCompaniesResponse> {
-  const params = new URLSearchParams();
-
-  params.set("page", String(page));
-  params.set("size", String(size));
-  if (sort) {
-    params.set("sort", sort);
-  }
-
-  const url = `${API_ENDPOINTS.ADMIN.COMPANIES.LIST}?${params.toString()}`;
+  const url = withQuery(API_ENDPOINTS.ADMIN.COMPANIES.LIST, {
+    page,
+    size,
+    sort: sort || undefined,
+  });
 
   return get<AdminCompaniesResponse>(url);
 }

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -16,8 +16,8 @@ import {
   CompanySignupRequestData,
   CompanySignupResponse,
 } from "@/types/auth";
-import { post, refreshAccessToken } from "@/lib/apiClient";
-import { API_ENDPOINTS, API_BASE_URL } from "@/constants/api";
+import { post, refreshAccessToken, apiRawRequest, ApiError } from "@/lib/apiClient";
+import { API_ENDPOINTS } from "@/constants/api";
 
 /**
  * 로그인 API 호출
@@ -30,13 +30,11 @@ import { API_ENDPOINTS, API_BASE_URL } from "@/constants/api";
  * - 리프레시 토큰: 백엔드에서 HttpOnly 쿠키로 자동 설정
  */
 export async function loginAPI(data: LoginFormData): Promise<LoginResponse> {
-  // 백엔드 직접 호출 (fetch 사용 - Response 헤더 접근 필요)
-  const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.AUTH.LOGIN}`, {
+  // raw Response가 필요(Authorization 응답 헤더 접근)하므로 apiRawRequest 사용.
+  // base URL / timeout / 네트워크 에러 변환은 공통 클라이언트 정책을 공유한다.
+  const response = await apiRawRequest(API_ENDPOINTS.AUTH.LOGIN, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    credentials: "include", // 리프레시 토큰 쿠키 받기 위해
+    skipAuth: true, // 로그인은 액세스 토큰 없이 호출
     body: JSON.stringify({
       email: data.email,
       password: data.password,
@@ -45,7 +43,11 @@ export async function loginAPI(data: LoginFormData): Promise<LoginResponse> {
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.message || "로그인에 실패했습니다");
+    throw new ApiError(
+      errorData.message || "로그인에 실패했습니다",
+      response.status,
+      errorData.code
+    );
   }
 
   // Authorization 헤더에서 액세스 토큰 추출
@@ -53,7 +55,7 @@ export async function loginAPI(data: LoginFormData): Promise<LoginResponse> {
   const accessToken = authHeader?.replace("Bearer ", "") || "";
 
   if (!accessToken) {
-    throw new Error("액세스 토큰을 받지 못했습니다");
+    throw new ApiError("액세스 토큰을 받지 못했습니다", response.status, "NO_ACCESS_TOKEN");
   }
 
   // 응답 바디 파싱
@@ -61,7 +63,7 @@ export async function loginAPI(data: LoginFormData): Promise<LoginResponse> {
 
   // 사용자 정보 검증
   if (!responseData.user) {
-    throw new Error("사용자 정보를 받지 못했습니다");
+    throw new ApiError("사용자 정보를 받지 못했습니다", response.status, "NO_USER");
   }
 
   // 액세스 토큰을 포함한 응답 반환

--- a/lib/api/inquiries.ts
+++ b/lib/api/inquiries.ts
@@ -4,6 +4,7 @@
 
 import { get, patch, post } from "@/lib/apiClient";
 import { API_ENDPOINTS } from "@/constants/api";
+import { withQuery } from "@/lib/http/query";
 import type {
   InquiryListParams,
   InquiryListResponse,
@@ -21,38 +22,16 @@ import type {
 export async function getAdminInquiries(
   params: InquiryListParams = {}
 ): Promise<InquiryListResponse> {
-  const searchParams = new URLSearchParams();
-
-  // 파라미터 구성
-  if (params.status) {
-    searchParams.append("status", params.status);
-  }
-  if (params.profileId !== undefined) {
-    searchParams.append("profileId", String(params.profileId));
-  }
-  if (params.profileName) {
-    searchParams.append("profileName", params.profileName);
-  }
-  if (params.receivedFrom) {
-    searchParams.append("receivedFrom", params.receivedFrom);
-  }
-  if (params.receivedTo) {
-    searchParams.append("receivedTo", params.receivedTo);
-  }
-  if (params.page !== undefined) {
-    searchParams.append("page", String(params.page));
-  }
-  if (params.size !== undefined) {
-    searchParams.append("size", String(params.size));
-  }
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((sortParam) => {
-      searchParams.append("sort", sortParam);
-    });
-  }
-
-  const queryString = searchParams.toString();
-  const endpoint = `${API_ENDPOINTS.ADMIN.INQUIRIES.LIST}${queryString ? `?${queryString}` : ""}`;
+  const endpoint = withQuery(API_ENDPOINTS.ADMIN.INQUIRIES.LIST, {
+    status: params.status || undefined,
+    profileId: params.profileId,
+    profileName: params.profileName || undefined,
+    receivedFrom: params.receivedFrom || undefined,
+    receivedTo: params.receivedTo || undefined,
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
 
   return get<InquiryListResponse>(endpoint);
 }

--- a/lib/api/jobPostings.ts
+++ b/lib/api/jobPostings.ts
@@ -1,6 +1,7 @@
 // lib/api/jobPostings.ts
 import { post, get, put, del } from "@/lib/apiClient";
 import { API_ENDPOINTS } from "@/constants/api";
+import { withQuery } from "@/lib/http/query";
 import type {
   Job,
   JobFormData,
@@ -191,25 +192,13 @@ export function fetchJobPostings(): Promise<Job[]> {
 export function fetchPublicJobPostings(
   params: PublicJobPostingsParams
 ): Promise<PublicJobPostingsResponse> {
-  const queryParams = new URLSearchParams();
-
-  if (params.jobGroupCode) {
-    queryParams.append("jobGroupCode", params.jobGroupCode);
-  }
-  if (params.jobRoleCode) {
-    queryParams.append("jobRoleCode", params.jobRoleCode);
-  }
-  if (params.page !== undefined) {
-    queryParams.append("page", params.page.toString());
-  }
-  if (params.size !== undefined) {
-    queryParams.append("size", params.size.toString());
-  }
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((s) => queryParams.append("sort", s));
-  }
-
-  const endpoint = `${API_ENDPOINTS.JOB_POSTINGS.LIST}?${queryParams.toString()}`;
+  const endpoint = withQuery(API_ENDPOINTS.JOB_POSTINGS.LIST, {
+    jobGroupCode: params.jobGroupCode || undefined,
+    jobRoleCode: params.jobRoleCode || undefined,
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
   return get<PublicJobPostingsResponse>(endpoint);
 }
 
@@ -220,16 +209,11 @@ export function fetchJobApplicants(
   jobId: string,
   params: JobApplicationsRequest
 ): Promise<CompanyApplicantsResponse> {
-  const queryParams = new URLSearchParams();
-
-  queryParams.append("page", params.page.toString());
-  queryParams.append("size", params.size.toString());
-
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((s) => queryParams.append("sort", s));
-  }
-
-  const endpoint = `${API_ENDPOINTS.COMPANY_JOB_POSTINGS.APPLICATIONS(jobId)}?${queryParams.toString()}`;
+  const endpoint = withQuery(API_ENDPOINTS.COMPANY_JOB_POSTINGS.APPLICATIONS(jobId), {
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
   return get<CompanyApplicantsResponse>(endpoint);
 }
 
@@ -239,28 +223,15 @@ export function fetchJobApplicants(
 export function fetchAdminJobPostings(
   params: PublicJobPostingsParams
 ): Promise<PublicJobPostingsResponse> {
-  const queryParams = new URLSearchParams();
-
-  // status는 빈 값으로 설정
-  queryParams.append("status", "");
-
-  if (params.jobGroupCode) {
-    queryParams.append("jobGroupCode", params.jobGroupCode);
-  }
-  if (params.jobRoleCode) {
-    queryParams.append("jobRoleCode", params.jobRoleCode);
-  }
-  if (params.page !== undefined) {
-    queryParams.append("page", params.page.toString());
-  }
-  if (params.size !== undefined) {
-    queryParams.append("size", params.size.toString());
-  }
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((s) => queryParams.append("sort", s));
-  }
-
-  const endpoint = `${API_ENDPOINTS.ADMIN.JOB_POSTINGS.LIST}?${queryParams.toString()}`;
+  const endpoint = withQuery(API_ENDPOINTS.ADMIN.JOB_POSTINGS.LIST, {
+    // status는 빈 값으로 전송 (전체 상태 조회)
+    status: "",
+    jobGroupCode: params.jobGroupCode || undefined,
+    jobRoleCode: params.jobRoleCode || undefined,
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
   return get<PublicJobPostingsResponse>(endpoint);
 }
 
@@ -271,15 +242,10 @@ export function fetchAdminJobApplicants(
   jobId: string,
   params: JobApplicationsRequest
 ): Promise<CompanyApplicantsResponse> {
-  const queryParams = new URLSearchParams();
-
-  queryParams.append("page", params.page.toString());
-  queryParams.append("size", params.size.toString());
-
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((s) => queryParams.append("sort", s));
-  }
-
-  const endpoint = `${API_ENDPOINTS.ADMIN.JOB_POSTINGS.APPLICATIONS(jobId)}?${queryParams.toString()}`;
+  const endpoint = withQuery(API_ENDPOINTS.ADMIN.JOB_POSTINGS.APPLICATIONS(jobId), {
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
   return get<CompanyApplicantsResponse>(endpoint);
 }

--- a/lib/api/serverJobPostings.ts
+++ b/lib/api/serverJobPostings.ts
@@ -1,5 +1,6 @@
 import { API_ENDPOINTS } from "@/constants/api";
 import { serverGet } from "@/lib/serverApiClient";
+import { withQuery } from "@/lib/http/query";
 import type {
   PublicJobPostingsParams,
   PublicJobPostingsResponse,
@@ -19,24 +20,12 @@ export function fetchPublicJobPostingServer(jobId: string): Promise<JobDetailRes
 export function fetchPublicJobPostingsServer(
   params: PublicJobPostingsParams
 ): Promise<PublicJobPostingsResponse> {
-  const queryParams = new URLSearchParams();
-
-  if (params.jobGroupCode) {
-    queryParams.append("jobGroupCode", params.jobGroupCode);
-  }
-  if (params.jobRoleCode) {
-    queryParams.append("jobRoleCode", params.jobRoleCode);
-  }
-  if (params.page !== undefined) {
-    queryParams.append("page", params.page.toString());
-  }
-  if (params.size !== undefined) {
-    queryParams.append("size", params.size.toString());
-  }
-  if (params.sort && params.sort.length > 0) {
-    params.sort.forEach((s) => queryParams.append("sort", s));
-  }
-
-  const endpoint = `${API_ENDPOINTS.JOB_POSTINGS.LIST}?${queryParams.toString()}`;
+  const endpoint = withQuery(API_ENDPOINTS.JOB_POSTINGS.LIST, {
+    jobGroupCode: params.jobGroupCode || undefined,
+    jobRoleCode: params.jobRoleCode || undefined,
+    page: params.page,
+    size: params.size,
+    sort: params.sort,
+  });
   return serverGet<PublicJobPostingsResponse>(endpoint);
 }

--- a/lib/api/talents.ts
+++ b/lib/api/talents.ts
@@ -2,6 +2,7 @@
 
 import { get } from "@/lib/apiClient";
 import { API_ENDPOINTS } from "@/constants/api";
+import { withQuery } from "@/lib/http/query";
 
 // 🔹 education 객체 타입 분리
 export type TalentEducation = {
@@ -77,22 +78,13 @@ export async function fetchTalents({
   jobRoleId,
   keyword,
 }: FetchTalentsParams = {}): Promise<TalentListResponse> {
-  const params = new URLSearchParams();
-
-  params.set("page", String(page));
-  params.set("size", String(size));
-
-  if (jobGroupId !== undefined) {
-    params.set("jobGroupId", String(jobGroupId));
-  }
-  if (jobRoleId !== undefined) {
-    params.set("jobRoleId", String(jobRoleId));
-  }
-  if (keyword && keyword.trim()) {
-    params.set("keyword", keyword.trim());
-  }
-
-  const url = `${API_ENDPOINTS.TALENTS.SEARCH}?${params.toString()}`;
+  const url = withQuery(API_ENDPOINTS.TALENTS.SEARCH, {
+    page,
+    size,
+    jobGroupId,
+    jobRoleId,
+    keyword: keyword?.trim() || undefined,
+  });
 
   return get<TalentListResponse>(url, {
     credentials: "include", // 쿠키 포함

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -160,6 +160,44 @@ async function handleResponseError(response: Response): Promise<never> {
 }
 
 /**
+ * 응답 본문 파싱
+ * - 204 / 빈 본문 / 비 JSON / 깨진 JSON을 모두 안전하게 빈 객체로 처리
+ * - 정상 경로와 401 재시도 경로가 동일한 규칙을 공유한다.
+ */
+export async function parseResponse<T>(response: Response): Promise<T> {
+  // 204 No Content 처리
+  if (response.status === HTTP_STATUS.NO_CONTENT) {
+    return {} as T;
+  }
+
+  // Content-Type 확인 및 빈 응답 처리
+  const contentType = response.headers.get("content-type");
+  const contentLength = response.headers.get("content-length");
+
+  // Content-Length가 0이거나 Content-Type이 JSON이 아닌 경우
+  if (contentLength === "0" || !contentType?.includes("application/json")) {
+    const text = await response.text();
+    if (!text || text.trim() === "") {
+      return {} as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return {} as T;
+    }
+  }
+
+  // JSON 응답 파싱
+  try {
+    const data = await response.json();
+    return data as T;
+  } catch {
+    console.warn("Failed to parse JSON response, returning empty object");
+    return {} as T;
+  }
+}
+
+/**
  * 토큰 리프레시 함수
  * - Authorization 헤더 우선, 없으면 응답 body에서 추출
  * - 앱 초기화(useInitializeAuth)와 401 자동 재시도에서 모두 사용
@@ -313,33 +351,7 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
           await handleResponseError(retryResponse);
         }
 
-        // 204 No Content 처리
-        if (retryResponse.status === HTTP_STATUS.NO_CONTENT) {
-          return {} as T;
-        }
-
-        // 빈 응답 처리
-        const retryContentType = retryResponse.headers.get("content-type");
-        const retryContentLength = retryResponse.headers.get("content-length");
-
-        if (retryContentLength === "0" || !retryContentType?.includes("application/json")) {
-          const text = await retryResponse.text();
-          if (!text || text.trim() === "") {
-            return {} as T;
-          }
-          try {
-            return JSON.parse(text) as T;
-          } catch {
-            return {} as T;
-          }
-        }
-
-        try {
-          const data = await retryResponse.json();
-          return data as T;
-        } catch {
-          return {} as T;
-        }
+        return parseResponse<T>(retryResponse);
       } catch (refreshError) {
         // 리프레시 실패 시 에러 전파 (clearAuth는 refreshAccessToken 내부에서 처리)
         throw refreshError;
@@ -351,39 +363,7 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
       await handleResponseError(response);
     }
 
-    // 204 No Content 처리
-    if (response.status === HTTP_STATUS.NO_CONTENT) {
-      return {} as T;
-    }
-
-    // Content-Type 확인 및 빈 응답 처리
-    const contentType = response.headers.get("content-type");
-    const contentLength = response.headers.get("content-length");
-
-    // Content-Length가 0이거나 Content-Type이 JSON이 아닌 경우
-    if (contentLength === "0" || !contentType?.includes("application/json")) {
-      // 빈 응답이면 빈 객체 반환
-      const text = await response.text();
-      if (!text || text.trim() === "") {
-        return {} as T;
-      }
-      // 텍스트가 있으면 JSON 파싱 시도
-      try {
-        return JSON.parse(text) as T;
-      } catch {
-        return {} as T;
-      }
-    }
-
-    // JSON 응답 파싱
-    try {
-      const data = await response.json();
-      return data as T;
-    } catch {
-      // JSON 파싱 실패 시 빈 객체 반환 (빈 응답인 경우)
-      console.warn("Failed to parse JSON response, returning empty object");
-      return {} as T;
-    }
+    return parseResponse<T>(response);
   } catch (error) {
     if (isDemoRequest && !recordedDemoResponse) {
       recordDemoApiLog({

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -107,6 +107,45 @@ async function fetchWithTimeout(url: string, options: RequestOptions = {}): Prom
 }
 
 /**
+ * raw Response가 필요한 요청을 위한 공통 래퍼
+ * - base URL resolution, timeout, 네트워크/타임아웃 ApiError 변환은 공유한다.
+ * - 응답 본문은 파싱하지 않고 raw Response를 그대로 반환한다(헤더 접근 등).
+ * - 로그인/리프레시처럼 Authorization 응답 헤더를 읽어야 하는 경로에서 사용한다.
+ * - demo 로컬 디스패치는 거치지 않는다(login/refresh는 항상 실제 백엔드 대상).
+ */
+export async function apiRawRequest(
+  endpoint: string,
+  options: RequestOptions = {}
+): Promise<Response> {
+  const { url } = resolveApiRequestUrl(endpoint);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (!options.skipAuth) {
+    const accessToken = useAuthStore.getState().accessToken;
+    if (accessToken) {
+      headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+  }
+
+  if (options.headers) {
+    Object.entries(options.headers).forEach(([key, value]) => {
+      if (typeof value === "string") {
+        headers[key] = value;
+      }
+    });
+  }
+
+  return fetchWithTimeout(url, {
+    ...options,
+    headers,
+    credentials: options.skipCredentials ? "omit" : "include",
+  });
+}
+
+/**
  * HTTP 응답 에러 처리
  */
 async function handleResponseError(response: Response): Promise<never> {

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -252,9 +252,9 @@ export async function refreshAccessToken(): Promise<string> {
   // 새로운 리프레시 Promise 생성
   refreshPromise = (async () => {
     try {
-      const response = await fetch(resolveApiRequestUrl(API_ENDPOINTS.AUTH.REFRESH_TOKEN).url, {
+      const response = await apiRawRequest(API_ENDPOINTS.AUTH.REFRESH_TOKEN, {
         method: "POST",
-        credentials: "include", // 리프레시 토큰 쿠키 포함
+        skipAuth: true, // 리프레시는 액세스 토큰이 아닌 쿠키 기반
       });
 
       if (!response.ok) {

--- a/lib/http/__tests__/query.test.ts
+++ b/lib/http/__tests__/query.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { withQuery } from "@/lib/http/query";
+
+describe("withQuery", () => {
+  it("appends provided params as a query string", () => {
+    expect(withQuery("/job-postings", { page: 0, size: 20 })).toBe("/job-postings?page=0&size=20");
+  });
+
+  it("omits undefined and null values", () => {
+    expect(
+      withQuery("/job-postings", {
+        jobGroupCode: undefined,
+        jobRoleCode: null,
+        page: 1,
+      })
+    ).toBe("/job-postings?page=1");
+  });
+
+  it("keeps empty string values (e.g. admin status='')", () => {
+    expect(withQuery("/admin/job-postings", { status: "", page: 0 })).toBe(
+      "/admin/job-postings?status=&page=0"
+    );
+  });
+
+  it("repeats array values under the same key and skips empty arrays", () => {
+    expect(withQuery("/job-postings", { sort: ["createdAt,desc", "id,asc"] })).toBe(
+      "/job-postings?sort=createdAt%2Cdesc&sort=id%2Casc"
+    );
+    expect(withQuery("/job-postings", { sort: [] })).toBe("/job-postings");
+  });
+
+  it("serializes numbers including zero", () => {
+    expect(withQuery("/profiles/search", { page: 0, size: 0 })).toBe(
+      "/profiles/search?page=0&size=0"
+    );
+  });
+
+  it("returns the endpoint unchanged when no params produce output (no trailing ?)", () => {
+    expect(withQuery("/job-postings", {})).toBe("/job-postings");
+    expect(withQuery("/job-postings", { jobGroupCode: undefined })).toBe("/job-postings");
+  });
+
+  it("preserves insertion order of keys", () => {
+    expect(withQuery("/x", { b: "2", a: "1", c: "3" })).toBe("/x?b=2&a=1&c=3");
+  });
+
+  it("encodes special characters", () => {
+    expect(withQuery("/x", { q: "a b&c" })).toBe("/x?q=a+b%26c");
+  });
+});

--- a/lib/http/query.ts
+++ b/lib/http/query.ts
@@ -1,0 +1,40 @@
+/**
+ * 쿼리 스트링 조립 유틸
+ *
+ * 도메인 API 함수마다 반복되던 `URLSearchParams` 조립을 한 곳으로 모은다.
+ * 규칙:
+ * - `undefined` / `null` 값은 생략한다.
+ * - 빈 문자열(`""`)은 값으로 포함한다. (예: 관리자 공고 목록의 `status=`)
+ * - 배열은 같은 key로 반복 append 하고, 빈 배열은 생략한다.
+ * - 숫자 0, boolean false 등도 값으로 포함한다.
+ * - 결과 쿼리가 비면 endpoint를 그대로 반환한다(trailing `?` 미부착).
+ */
+
+export type QueryPrimitive = string | number | boolean;
+
+export type QueryParams = Record<string, QueryPrimitive | QueryPrimitive[] | null | undefined>;
+
+export function withQuery(endpoint: string, params: QueryParams = {}): string {
+  const search = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) {
+          continue;
+        }
+        search.append(key, String(item));
+      }
+      continue;
+    }
+
+    search.append(key, String(value));
+  }
+
+  const queryString = search.toString();
+  return queryString ? `${endpoint}?${queryString}` : endpoint;
+}


### PR DESCRIPTION
Closes #41

## 요약
3계층 API 구조의 원칙("공통 관심사는 apiClient에 한 번만 구현된다")을 코드와 일치시킨다. 외부 동작(요청/응답 결과)은 바꾸지 않는다.

## 변경 사항
- [x] T1: withQuery 쿼리 스트링 유틸 + 테스트
- [x] T2: 도메인 함수 5파일에 withQuery 적용 (lib/api의 URLSearchParams 5곳 → 0곳, query string 동일 보장)
- [x] T3: parseResponse 추출 (정상/401 재시도 경로 파싱 중복 제거)
- [x] T4: apiRawRequest 추가 (base URL/timeout/에러 변환 공유, raw Response 반환)
- [x] T5: login/refresh를 apiRawRequest로 이전, loginAPI 실패를 ApiError로 통일
- [x] T6: 설명 문서 + 회고 슬라이드 (docs/, gitignore되어 로컬 산출물)

## 검증
- [x] npm run type-check
- [x] npm run lint
- [x] npm run test (239 passed, 신규 35케이스 포함)
- [x] npm run build

## 인증 경로 리스크 (Adversarial)
- login/refresh가 apiRawRequest 경유로 timeout·Content-Type이 새로 적용되나 refresh는 쿠키 기반이라 무해. 기존 동시성 회귀 테스트로 무회귀 확인.
- 데모 모드 로그인은 CTA interception 경로라 loginAPI 미호출 → 영향 없음.
- 롤백: 각 task 단일 커밋이라 revert 용이.